### PR TITLE
Changed iterative error to warning. This stops gridsearch breaking if…

### DIFF
--- a/cca_zoo/models/innerloop.py
+++ b/cca_zoo/models/innerloop.py
@@ -142,7 +142,8 @@ class PLSInnerLoop(_InnerLoop):
     def _inner_iteration(self):
         # Update each view using loop update function
         for i, view in enumerate(self.views):
-            self._update_view(i)
+            if np.isnan(self.scores).sum() == 0:
+                self._update_view(i)
 
     @abstractmethod
     def _update_view(self, view_index: int):


### PR DESCRIPTION
… just one parameter is in the wrong range