### PR TITLE
Changed iterative error to warning. This stops gridsearch breaking if…

### DIFF
--- a/cca_zoo/models/iterative.py
+++ b/cca_zoo/models/iterative.py
@@ -368,7 +368,7 @@ class CCA_ALS(ElasticCCA):
             scale=scale,
             positive=positive,
             random_state=random_state,
-            c=0,
+            c=1e-5,
             maxvar=False,
         )
 


### PR DESCRIPTION
… just one parameter is in the wrong range