### PR TITLE
fixes #149

### DIFF
--- a/cca_zoo/model_selection/_search.py
+++ b/cca_zoo/model_selection/_search.py
@@ -294,7 +294,7 @@ class RandomizedSearchCV(BaseSearchCV):
                 ("estimator", clone(self.estimator)),
             ]
         )
-        self = BaseSearchCV.fit(self, np.hstack(X), y=None, groups=None, **fit_params)
+        self = BaseSearchCV.fit(self, np.hstack(X), y=y, groups=groups, **fit_params)
         self.best_estimator_ = self.best_estimator_["estimator"]
         self.best_params_ = {
             key[len("estimator__") :]: val for key, val in self.best_params_.items()


### PR DESCRIPTION
`y` and `groups` have to be passed down from `cca_zoo.model_selection.GridSearchCV` to `sklearn.model_selection._search.BaseSearchCV`