### PR TITLE
added all places where sphinx creates files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,8 +78,11 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
-doc/_build/
+docs/source/_build/
+docs/source/_autosummary/
+docs/source/auto_examples/
+docs/source/examples/lightning_logs/
+docs/source/examples/MNIST/
 
 # PyBuilder
 target/


### PR DESCRIPTION
I generated all the docs locally
I then observed where new files were added (clearly highlighted green in my vs code editor)
Then added each of the offending directories to gitignore
Did not try to restructure the code to make fewer directories of sphinx output - think this might be a good piece of code hygiene to perform at some point - but not my area of expertise