### PR TITLE
Add algorithmic correctness tests across all model families

### DIFF
--- a/tests/linear/test_eigendecomposition.py
+++ b/tests/linear/test_eigendecomposition.py
@@ -417,3 +417,39 @@ def test_pairwise_correlations_shape_three_view(
     model = MCCA(latent_dimensions=k).fit(three_views)
     corrs = model.pairwise_correlations(three_views)
     assert corrs.shape == (3, 3, k)
+
+
+# ---------------------------------------------------------------------------
+# Mathematical properties / correctness
+# ---------------------------------------------------------------------------
+
+
+def test_mcca_two_views_matches_cca(correlated_views: list[np.ndarray]) -> None:
+    """MCCA with two views is equivalent to CCA (same canonical correlations)."""
+    k = 2
+    s_cca = CCA(latent_dimensions=k).fit(correlated_views).score(correlated_views)
+    s_mcca = MCCA(latent_dimensions=k).fit(correlated_views).score(correlated_views)
+    np.testing.assert_allclose(s_mcca, s_cca, atol=1e-6)
+
+
+def test_cca_canonical_variates_are_uncorrelated() -> None:
+    """CCA canonical variates are orthogonal across dimensions (unit-variance, decorrelated)."""
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((100, 10))
+    k = 3
+    model = CCA(latent_dimensions=k).fit([x, x])
+    Z = model.transform([x, x])
+    for z in Z:
+        corr = np.corrcoef(z.T)
+        off_diag = corr - np.eye(k)
+        np.testing.assert_allclose(off_diag, 0.0, atol=1e-6)
+
+
+def test_tcca_finds_high_correlation(correlated_views: list[np.ndarray]) -> None:
+    """TCCA finds high correlation on clearly correlated views."""
+    s = (
+        TCCA(latent_dimensions=1, random_state=0)
+        .fit(correlated_views)
+        .score(correlated_views)
+    )
+    assert np.all(s > 0.8), f"Expected high correlation, got {s}"

--- a/tests/linear/test_eigendecomposition.py
+++ b/tests/linear/test_eigendecomposition.py
@@ -433,7 +433,7 @@ def test_mcca_two_views_matches_cca(correlated_views: list[np.ndarray]) -> None:
 
 
 def test_cca_canonical_variates_are_uncorrelated() -> None:
-    """CCA canonical variates are orthogonal across dimensions (unit-variance, decorrelated)."""
+    """CCA canonical variates are orthogonal across dimensions."""
     rng = np.random.default_rng(0)
     x = rng.standard_normal((100, 10))
     k = 3

--- a/tests/linear/test_iterative.py
+++ b/tests/linear/test_iterative.py
@@ -297,3 +297,35 @@ def test_pairwise_correlations_shape(
     model = ModelClass(latent_dimensions=k, max_iter=50, random_state=0).fit(two_views)
     corrs = model.pairwise_correlations(two_views)
     assert corrs.shape == (2, 2, k)
+
+
+# ---------------------------------------------------------------------------
+# Correctness / optimality
+# ---------------------------------------------------------------------------
+
+
+def test_pls_als_matches_pls(correlated_views: list[np.ndarray]) -> None:
+    """PLS_ALS (converged) recovers the same correlations as exact PLS."""
+    from cca_zoo.linear import PLS
+
+    k = 2
+    s_pls = PLS(latent_dimensions=k).fit(correlated_views).score(correlated_views)
+    s_als = (
+        PLS_ALS(latent_dimensions=k, max_iter=1000, random_state=0)
+        .fit(correlated_views)
+        .score(correlated_views)
+    )
+    np.testing.assert_allclose(s_als, s_pls, atol=0.05)
+
+
+def test_iterative_models_find_high_correlation(
+    correlated_views: list[np.ndarray],
+) -> None:
+    """All iterative models find substantial correlation on clearly correlated views."""
+    for ModelClass in ALL_ITERATIVE_MODELS:
+        s = (
+            ModelClass(latent_dimensions=1, max_iter=500, random_state=0)
+            .fit(correlated_views)
+            .score(correlated_views)
+        )
+        assert np.all(s > 0.5), f"{ModelClass.__name__} got low correlation: {s}"

--- a/tests/nonparametric/test_kernel.py
+++ b/tests/nonparametric/test_kernel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from cca_zoo.linear import CCA
 from cca_zoo.nonparametric import KCCA, KGCCA, KTCCA
 
 ALL_KERNEL_MODELS = [KCCA, KGCCA, KTCCA]
@@ -274,3 +275,47 @@ def test_pairwise_correlations_shape(
     model = _make_kernel_model(ModelClass, latent_dimensions=k).fit(two_views_small)
     corrs = model.pairwise_correlations(two_views_small)
     assert corrs.shape == (2, 2, k)
+
+
+# ---------------------------------------------------------------------------
+# Correctness / optimality
+# ---------------------------------------------------------------------------
+
+
+def test_kcca_linear_kernel_matches_cca(correlated_views: list[np.ndarray]) -> None:
+    """KCCA with a linear kernel recovers the same correlations as CCA (small c)."""
+    k = 2
+    s_cca = CCA(latent_dimensions=k).fit(correlated_views).score(correlated_views)
+    s_kcca = (
+        KCCA(latent_dimensions=k, kernel="linear", c=1e-4)
+        .fit(correlated_views)
+        .score(correlated_views)
+    )
+    np.testing.assert_allclose(s_kcca, s_cca, atol=1e-3)
+
+
+def test_kcca_finds_high_correlation(correlated_views: list[np.ndarray]) -> None:
+    """KCCA with rbf kernel finds high correlation on clearly correlated views."""
+    s = (
+        KCCA(latent_dimensions=1, c=0.01, kernel="rbf")
+        .fit(correlated_views)
+        .score(correlated_views)
+    )
+    assert np.all(s > 0.8), f"Expected high correlation, got {s}"
+
+
+def test_kcca_regularisation_reduces_correlation(
+    correlated_views: list[np.ndarray],
+) -> None:
+    """Higher regularisation c gives lower (or equal) training correlation."""
+    s_low = (
+        KCCA(latent_dimensions=1, kernel="linear", c=1e-4)
+        .fit(correlated_views)
+        .score(correlated_views)
+    )
+    s_high = (
+        KCCA(latent_dimensions=1, kernel="linear", c=10.0)
+        .fit(correlated_views)
+        .score(correlated_views)
+    )
+    assert s_low[0] >= s_high[0] - 1e-6


### PR DESCRIPTION
- Eigendecomposition: MCCA(2 views)==CCA, CCA variate orthogonality, TCCA finds high correlation
- Iterative: PLS_ALS converges to PLS, all sparse models find >0.5 correlation
- Kernel: KCCA(linear, c→0)==CCA, KCCA finds high correlation, higher c reduces correlation