### PR TITLE
Fix CI publish job not triggering on version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main, "rewrite/**"]
+    tags: ["v*"]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Add tags: ["v*"] to the push trigger so the workflow fires when a tag is pushed, allowing the publish job's if-condition to match.