### PR TITLE
Fix CI: mypy/numpy stub mismatch and stale ruff-format drift on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ data = JointData(
     random_state=0,
 )
 train_views = data.sample()
-test_views  = data.sample()
+test_views = data.sample()
 
 # Fit CCA and evaluate
 model = CCA(latent_dimensions=2).fit(train_views)
-print(model.score(test_views))     # canonical correlations, shape (2,)
+print(model.score(test_views))  # canonical correlations, shape (2,)
 
 # Project views into the shared latent space
 z1, z2 = model.transform(test_views)  # each shape (200, 2)

--- a/cca_zoo/linear/_iterative.py
+++ b/cca_zoo/linear/_iterative.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 from abc import abstractmethod
+from typing import cast
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -810,7 +811,7 @@ class ElasticCCA(_BaseIterative):
             target /= norm
         reg = self._regressors[i]
         reg.fit(views[i], target)
-        return np.atleast_1d(reg.coef_).ravel()
+        return cast(np.ndarray, np.atleast_1d(reg.coef_).ravel())
 
 
 # ---------------------------------------------------------------------------

--- a/cca_zoo/linear/gradient/_pls_ey.py
+++ b/cca_zoo/linear/gradient/_pls_ey.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 from numpy.typing import ArrayLike
 
@@ -83,7 +85,7 @@ class PLS_EY(BaseGradientModel):
         Returns:
             Matrix of shape (k, k).
         """
-        return sum(w.T @ w for w in weights) / len(weights)
+        return cast(np.ndarray, sum(w.T @ w for w in weights) / len(weights))
 
     def _derivative(
         self,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,8 +35,8 @@ pip install cca-zoo[all]           # Everything above
 CCA-Zoo expects data as a **list of arrays**, one per view:
 
 ```python
-views = [X1, X2]          # two views
-views = [X1, X2, X3]      # three views
+views = [X1, X2]  # two views
+views = [X1, X2, X3]  # three views
 ```
 
 Each array has shape `(n_samples, n_features_i)`. All views must share the same number of rows.
@@ -49,8 +49,8 @@ Every model follows the same three-step pattern:
 from cca_zoo.linear import CCA
 
 model = CCA(latent_dimensions=2)  # 1. construct
-model.fit(views)                   # 2. fit
-z = model.transform(views)         # 3. use
+model.fit(views)  # 2. fit
+z = model.transform(views)  # 3. use
 ```
 
 Or equivalently:
@@ -64,8 +64,8 @@ z = CCA(latent_dimensions=2).fit_transform(views)
 `score` returns the average pairwise canonical correlation per latent dimension:
 
 ```python
-corrs = model.score(views)   # np.ndarray, shape (latent_dimensions,)
-print(corrs)                  # e.g. [0.94, 0.87]
+corrs = model.score(views)  # np.ndarray, shape (latent_dimensions,)
+print(corrs)  # e.g. [0.94, 0.87]
 ```
 
 ### Inspecting weights
@@ -73,7 +73,7 @@ print(corrs)                  # e.g. [0.94, 0.87]
 After fitting, `model.weights` is a list of weight matrices (one per view):
 
 ```python
-W1, W2 = model.weights   # each shape (n_features_i, latent_dimensions)
+W1, W2 = model.weights  # each shape (n_features_i, latent_dimensions)
 ```
 
 ---
@@ -97,7 +97,7 @@ data = JointData(
     random_state=0,
 )
 train_views = data.sample()
-test_views  = data.sample()
+test_views = data.sample()
 
 # Fit and evaluate
 model = CCA(latent_dimensions=2).fit(train_views)

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,8 +87,8 @@ model.fit([X1, X2])
 
 # 3. use
 z1, z2 = model.transform([X1, X2])
-corrs  = model.score([X1, X2])    # canonical correlations, shape (2,)
-W1, W2 = model.weights            # weight matrices
+corrs = model.score([X1, X2])  # canonical correlations, shape (2,)
+W1, W2 = model.weights  # weight matrices
 ```
 
 Models are `sklearn.base.BaseEstimator` subclasses, so they work directly with

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -28,14 +28,14 @@ from cca_zoo.datasets import JointData
 data = JointData(
     n_views=2,
     n_samples=200,
-    n_features=[50, 40],       # different feature counts per view
+    n_features=[50, 40],  # different feature counts per view
     latent_dimensions=2,
-    signal_to_noise=2.0,       # higher = less noise
+    signal_to_noise=2.0,  # higher = less noise
     random_state=0,
 )
 
-train_views = data.sample()    # list of 2 arrays: (200, 50), (200, 40)
-test_views  = data.sample()    # independent sample from the same model
+train_views = data.sample()  # list of 2 arrays: (200, 50), (200, 40)
+test_views = data.sample()  # independent sample from the same model
 ```
 
 ### Parameters
@@ -53,11 +53,14 @@ test_views  = data.sample()    # independent sample from the same model
 
 ```python
 # Same features for all views (scalar broadcasts)
-data = JointData(n_views=3, n_samples=100, n_features=20, latent_dimensions=2, random_state=0)
+data = JointData(
+    n_views=3, n_samples=100, n_features=20, latent_dimensions=2, random_state=0
+)
 
 # Different SNR per view
-data = JointData(n_views=2, n_samples=100, n_features=20,
-                 signal_to_noise=[4.0, 1.0], random_state=0)
+data = JointData(
+    n_views=2, n_samples=100, n_features=20, signal_to_noise=[4.0, 1.0], random_state=0
+)
 
 # Callable shorthand (same as sample())
 views = data()
@@ -80,8 +83,8 @@ Wraps `sklearn.datasets.load_linnerud`. Returns two arrays:
 from cca_zoo.datasets import load_linnerud
 
 exercise, physiological = load_linnerud()
-print(exercise.shape)        # (20, 3)
-print(physiological.shape)   # (20, 3)
+print(exercise.shape)  # (20, 3)
+print(physiological.shape)  # (20, 3)
 ```
 
 ### `load_breast_cancer`
@@ -96,6 +99,6 @@ a two-view dataset:
 from cca_zoo.datasets import load_breast_cancer
 
 view1, view2 = load_breast_cancer()
-print(view1.shape)   # (569, 15)
-print(view2.shape)   # (569, 15)
+print(view1.shape)  # (569, 15)
+print(view2.shape)  # (569, 15)
 ```

--- a/docs/user-guide/deep.md
+++ b/docs/user-guide/deep.md
@@ -22,7 +22,7 @@ from cca_zoo.deep import DCCA
 
 # Define encoders for each view
 encoder1 = nn.Sequential(nn.Linear(100, 64), nn.ReLU(), nn.Linear(64, 16))
-encoder2 = nn.Sequential(nn.Linear(80,  64), nn.ReLU(), nn.Linear(64, 16))
+encoder2 = nn.Sequential(nn.Linear(80, 64), nn.ReLU(), nn.Linear(64, 16))
 
 model = DCCA(
     latent_dimensions=8,
@@ -39,9 +39,10 @@ import lightning as L
 from torch.utils.data import DataLoader, TensorDataset
 import torch
 
-dataset = TensorDataset(torch.tensor(X1, dtype=torch.float32),
-                        torch.tensor(X2, dtype=torch.float32))
-loader  = DataLoader(dataset, batch_size=64, shuffle=True)
+dataset = TensorDataset(
+    torch.tensor(X1, dtype=torch.float32), torch.tensor(X2, dtype=torch.float32)
+)
+loader = DataLoader(dataset, batch_size=64, shuffle=True)
 
 trainer = L.Trainer(max_epochs=50)
 trainer.fit(model, loader)
@@ -50,10 +51,13 @@ trainer.fit(model, loader)
 After training, `transform` takes a DataLoader and returns the encoded representations:
 
 ```python
-test_loader = DataLoader(TensorDataset(
-    torch.tensor(X1_test, dtype=torch.float32),
-    torch.tensor(X2_test, dtype=torch.float32),
-), batch_size=256)
+test_loader = DataLoader(
+    TensorDataset(
+        torch.tensor(X1_test, dtype=torch.float32),
+        torch.tensor(X2_test, dtype=torch.float32),
+    ),
+    batch_size=256,
+)
 
 z1, z2 = model.transform(test_loader)
 ```
@@ -133,7 +137,7 @@ model = DCCAE(
     latent_dimensions=8,
     encoders=[e1, e2],
     decoders=[decoder1, decoder2],
-    lam=0.01,   # reconstruction loss weight
+    lam=0.01,  # reconstruction loss weight
 )
 ```
 
@@ -206,14 +210,16 @@ from cca_zoo.datasets import JointData
 from cca_zoo.deep import DCCA
 
 # Simulate data
-data = JointData(n_views=2, n_samples=1000, n_features=[100, 80],
-                 latent_dimensions=4, random_state=0)
+data = JointData(
+    n_views=2, n_samples=1000, n_features=[100, 80], latent_dimensions=4, random_state=0
+)
 views = data.sample()
 
 X1 = torch.tensor(views[0], dtype=torch.float32)
 X2 = torch.tensor(views[1], dtype=torch.float32)
 
 train_loader = DataLoader(TensorDataset(X1, X2), batch_size=64, shuffle=True)
+
 
 # Build encoders
 def make_encoder(in_features: int, latent_dim: int) -> nn.Module:
@@ -223,6 +229,7 @@ def make_encoder(in_features: int, latent_dim: int) -> nn.Module:
         nn.ReLU(),
         nn.Linear(128, latent_dim),
     )
+
 
 model = DCCA(
     latent_dimensions=4,
@@ -236,7 +243,7 @@ trainer.fit(model, train_loader)
 # Evaluate
 test_loader = DataLoader(TensorDataset(X1, X2), batch_size=256)
 z1, z2 = model.transform(test_loader)
-print("Representation shape:", z1.shape)   # (1000, 4)
+print("Representation shape:", z1.shape)  # (1000, 4)
 ```
 
 ---

--- a/docs/user-guide/linear.md
+++ b/docs/user-guide/linear.md
@@ -29,7 +29,7 @@ from cca_zoo.linear import CCA
 
 model = CCA(latent_dimensions=2).fit([X1, X2])
 z1, z2 = model.transform([X1, X2])
-print(model.score([X1, X2]))   # canonical correlations
+print(model.score([X1, X2]))  # canonical correlations
 ```
 
 ### rCCA — Regularised CCA
@@ -207,7 +207,9 @@ Uses an elastic net regression (sklearn) at each ALS step (Mai & Zhang 2019).
 ```python
 from cca_zoo.linear import SCCA_IPLS
 
-model = SCCA_IPLS(latent_dimensions=2, alpha=0.01, l1_ratio=1.0, random_state=0).fit([X1, X2])
+model = SCCA_IPLS(latent_dimensions=2, alpha=0.01, l1_ratio=1.0, random_state=0).fit(
+    [X1, X2]
+)
 ```
 
 ### ElasticCCA
@@ -218,7 +220,9 @@ the sum-of-all-other-view scores against the current view via elastic net.
 ```python
 from cca_zoo.linear import ElasticCCA
 
-model = ElasticCCA(latent_dimensions=2, alpha=0.01, l1_ratio=0.5, random_state=0).fit([X1, X2])
+model = ElasticCCA(latent_dimensions=2, alpha=0.01, l1_ratio=0.5, random_state=0).fit(
+    [X1, X2]
+)
 ```
 
 ### ParkhomenkoCCA

--- a/docs/user-guide/model-selection.md
+++ b/docs/user-guide/model-selection.md
@@ -41,8 +41,9 @@ param_grid = {"c": [0.01, 0.1, 1.0]}
 # Per-view c (list of two values for a two-view model)
 param_grid = {"c": [[0.01, 0.1], [0.1, 1.0]]}
 
-gs = GridSearchCV(KCCA(latent_dimensions=2, kernel="rbf", gamma=0.01),
-                  param_grid=param_grid, cv=5)
+gs = GridSearchCV(
+    KCCA(latent_dimensions=2, kernel="rbf", gamma=0.01), param_grid=param_grid, cv=5
+)
 gs.fit([X1, X2])
 ```
 
@@ -55,7 +56,9 @@ import pandas as pd
 
 # Full CV results table
 df = pd.DataFrame(gs.cv_results_)
-print(df[["param_c", "mean_test_score", "std_test_score"]].sort_values("mean_test_score"))
+print(
+    df[["param_c", "mean_test_score", "std_test_score"]].sort_values("mean_test_score")
+)
 
 # Best parameters and score
 print(gs.best_params_)
@@ -76,8 +79,14 @@ from cca_zoo.model_selection import GridSearchCV
 from cca_zoo.nonparametric import KCCA
 
 # Simulate data
-data = JointData(n_views=2, n_samples=200, n_features=[30, 30],
-                 latent_dimensions=2, signal_to_noise=2.0, random_state=0)
+data = JointData(
+    n_views=2,
+    n_samples=200,
+    n_features=[30, 30],
+    latent_dimensions=2,
+    signal_to_noise=2.0,
+    random_state=0,
+)
 views = data.sample()
 
 # Grid search over kernel and regularisation

--- a/docs/user-guide/nonparametric.md
+++ b/docs/user-guide/nonparametric.md
@@ -104,7 +104,9 @@ PARAFAC decomposition:
 ```python
 from cca_zoo.nonparametric import KTCCA
 
-model = KTCCA(latent_dimensions=2, kernel="rbf", gamma=0.01, c=0.1, random_state=0).fit([X1, X2, X3])
+model = KTCCA(latent_dimensions=2, kernel="rbf", gamma=0.01, c=0.1, random_state=0).fit(
+    [X1, X2, X3]
+)
 ```
 
 ---
@@ -142,10 +144,12 @@ Pass any callable with signature `k(X, Y, **params) -> np.ndarray`:
 import numpy as np
 from cca_zoo.nonparametric import KCCA
 
+
 def my_kernel(X, Y, sigma=1.0):
     """Gaussian kernel with explicit sigma."""
     diff = X[:, None, :] - Y[None, :, :]
     return np.exp(-np.sum(diff**2, axis=-1) / (2 * sigma**2))
+
 
 model = KCCA(
     latent_dimensions=2,

--- a/docs/user-guide/probabilistic.md
+++ b/docs/user-guide/probabilistic.md
@@ -67,7 +67,9 @@ $$
 $$
 
 ```python
-z = model.transform([X1, X2])   # list with one array of shape (n_samples, latent_dimensions)
+z = model.transform(
+    [X1, X2]
+)  # list with one array of shape (n_samples, latent_dimensions)
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,12 @@ convention = "google"
 
 [tool.mypy]
 strict = true
-python_version = "3.10"
+# Matches the Python version the "Typecheck (mypy)" CI job actually runs on
+# (a single, non-matrixed job). This must track that job's setup-python
+# version: newer numpy releases ship stub files using syntax (e.g. PEP 695
+# `type` aliases) that requires mypy's target to be >= the numpy stub's
+# minimum Python, regardless of the package's own `requires-python` floor.
+python_version = "3.12"
 ignore_missing_imports = true
 disable_error_code = ["misc", "untyped-decorator"]
 


### PR DESCRIPTION
## Summary

`main`'s CI (`Lint (ruff)` and `Typecheck (mypy)`) has been red since 37f915f, unrelated to that commit's own content:

- **mypy**: `numpy==2.5.1`'s `__init__.pyi` uses a PEP 695 `type` alias statement, which mypy can only parse when its configured target is Python ≥3.12. `pyproject.toml` had `[tool.mypy] python_version = "3.10"`, but the `Typecheck (mypy)` CI job is a single, non-matrixed job that always runs on Python 3.12 — so the pin no longer matched the interpreter actually resolving `numpy`. Bumped it to `3.12` to match reality (the package's own `requires-python = ">=3.10"` floor is untouched; this only affects mypy's own analysis target, not the tests, which still run as a 3.10/3.11/3.12 matrix).
- With that fixed, mypy surfaced two genuine pre-existing `no-any-return` errors it had never reached before (sklearn's untyped `.coef_"` attribute in `linear/_iterative.py`, and a generator-`sum` that loses its `ndarray` type in `linear/gradient/_pls_ey.py`). Fixed both with an explicit `cast`, matching the pattern already used elsewhere in the codebase (e.g. `_base.py`, `_grcca.py`).
- **ruff format**: several `docs/*.md` files (and `README.md`) had drifted out of sync with `ruff format`'s handling of embedded Python code fences. Ran `ruff format .` to bring them back in line — purely whitespace/line-wrapping, no code semantics changed.

## Test plan

- [x] Reproduced the exact CI failure locally (Python 3.12 venv, `numpy==2.5.1`)
- [x] `mypy cca_zoo` — clean
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `pytest tests/ -m "not slow"` — 388 passed
- [x] `mkdocs build --strict` — succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL3GT9jTbPvuCwbvmztghe)_