### PR TITLE
Fix dead sklearn tags, wire up doctests, add docs-coverage test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,15 @@ jobs:
       - name: Run fast tests
         run: uv run pytest -m "not slow" --cov=cca_zoo --cov-report=xml
 
+      # Only the modules importable without optional heavy deps (torch,
+      # xgboost, numpyro/jax) — same rationale as the "not slow" filter
+      # above. Runs once since doctest results don't vary by interpreter.
+      - name: Run doctests
+        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+        run: |
+          uv run pytest --doctest-modules --no-cov \
+            cca_zoo/linear cca_zoo/nonparametric cca_zoo/datasets cca_zoo/model_selection
+
       - name: Upload coverage
         uses: codecov/codecov-action@v4
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'

--- a/cca_zoo/_base.py
+++ b/cca_zoo/_base.py
@@ -8,6 +8,7 @@ from typing import cast
 import numpy as np
 from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted
 
 from cca_zoo._utils._validation import validate_views
@@ -216,10 +217,22 @@ class BaseModel(BaseEstimator, ABC):
     # Sklearn compatibility
     # ------------------------------------------------------------------
 
-    def _more_tags(self) -> dict[str, object]:
-        """Return sklearn tag overrides.
+    def __sklearn_tags__(self) -> Tags:
+        """Return sklearn tags, corrected for this class's non-standard ``fit``.
+
+        ``BaseModel`` subclasses deliberately don't conform to sklearn's
+        standard estimator interface: ``fit``/``transform``/``score`` take a
+        *list* of per-view arrays, not a single 2-D ``X``, so sklearn's own
+        input validation and common estimator checks don't apply. This is
+        surfaced honestly via tags rather than left to silently mismatch.
 
         Returns:
-            Dictionary of sklearn tag overrides.
+            Tags: sklearn tags with ``no_validation`` and ``_skip_test`` set,
+            and ``input_tags.two_d_array`` cleared since a bare 2-D array is
+            not a valid input on its own.
         """
-        return {"multioutput": True}
+        tags = super().__sklearn_tags__()
+        tags.no_validation = True
+        tags.input_tags.two_d_array = False
+        tags._skip_test = True
+        return tags

--- a/cca_zoo/linear/gradient/_cca_ey.py
+++ b/cca_zoo/linear/gradient/_cca_ey.py
@@ -53,7 +53,7 @@ class CCA_EY(BaseGradientModel):
         >>> X1 = rng.standard_normal((200, 500))
         >>> X2 = rng.standard_normal((200, 400))
         >>> model = CCA_EY(latent_dimensions=4, c=0.1, batch_size=64, random_state=0)
-        >>> model.fit([X1, X2])
+        >>> model = model.fit([X1, X2])
     """
 
     def __init__(

--- a/cca_zoo/linear/gradient/_mcca_ey.py
+++ b/cca_zoo/linear/gradient/_mcca_ey.py
@@ -37,7 +37,7 @@ class MCCA_EY(CCA_EY):
         >>> X2 = rng.standard_normal((200, 400))
         >>> X3 = rng.standard_normal((200, 300))
         >>> model = MCCA_EY(latent_dimensions=4, c=0.1, batch_size=64, random_state=0)
-        >>> model.fit([X1, X2, X3])
+        >>> model = model.fit([X1, X2, X3])
     """
 
     def fit(self, views: list[ArrayLike], y: None = None) -> MCCA_EY:

--- a/cca_zoo/linear/gradient/_pls_ey.py
+++ b/cca_zoo/linear/gradient/_pls_ey.py
@@ -54,7 +54,7 @@ class PLS_EY(BaseGradientModel):
         >>> X1 = rng.standard_normal((200, 500))
         >>> X2 = rng.standard_normal((200, 400))
         >>> model = PLS_EY(latent_dimensions=4, batch_size=64, random_state=0)
-        >>> model.fit([X1, X2])
+        >>> model = model.fit([X1, X2])
     """
 
     def fit(self, views: list[ArrayLike], y: None = None) -> PLS_EY:

--- a/cca_zoo/model_selection/_search.py
+++ b/cca_zoo/model_selection/_search.py
@@ -31,7 +31,7 @@ class _MultiviewWrapper(BaseEstimator):
         >>> X1 = np.random.randn(50, 5)
         >>> X2 = np.random.randn(50, 4)
         >>> wrapper = _MultiviewWrapper(CCA(), split_indices=[5, 4])
-        >>> wrapper.fit(np.hstack([X1, X2]))
+        >>> wrapper = wrapper.fit(np.hstack([X1, X2]))
     """
 
     def __init__(
@@ -168,7 +168,7 @@ class GridSearchCV:
         >>> gs = GridSearchCV(
         ...     CCA(), param_grid={"latent_dimensions": [1, 2]}, cv=2
         ... )
-        >>> gs.fit([X1, X2])
+        >>> gs = gs.fit([X1, X2])
     """
 
     def __init__(

--- a/cca_zoo/probabilistic/_pcca.py
+++ b/cca_zoo/probabilistic/_pcca.py
@@ -203,11 +203,3 @@ class ProbabilisticCCA(BaseModel):
         sigma_z = np.linalg.inv(precision)  # (k, k) — symmetric
         mu_z = information @ sigma_z  # (n, k)
         return [mu_z]
-
-    def _more_tags(self) -> dict[str, object]:
-        """Return sklearn tag overrides.
-
-        Returns:
-            Dictionary indicating this is a probabilistic model.
-        """
-        return {"multioutput": True, "no_validation": True}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.26",
     "scipy>=1.11",
-    "scikit-learn>=1.4",
+    "scikit-learn>=1.6",
     "tensorly>=0.8",
 ]
 

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -1,0 +1,60 @@
+"""Ensures every public API symbol has a docs/api/*.md entry.
+
+This directly guards against the failure mode that let several v2.6.0
+models go undocumented (and briefly GRCCA/PartialCCA/DMCCA/DGCCA too): a
+class gets added to a module's ``__all__`` but nobody remembers to add a
+matching mkdocstrings ``::: `` line to the corresponding API reference
+page. docs/api/*.md isn't auto-generated from ``__all__`` (it's hand
+-curated into meaningful categories with headers), so this test is the
+mechanical backstop that catches the gap instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+
+DOCS_API_DIR = Path(__file__).parent.parent / "docs" / "api"
+
+# Importable module name -> docs/api/*.md filename. Usually the same name;
+# model_selection is the one exception (hyphenated filename).
+MODULE_DOC_PAGES = {
+    "cca_zoo.linear": "linear.md",
+    "cca_zoo.deep": "deep.md",
+    "cca_zoo.nonparametric": "nonparametric.md",
+    "cca_zoo.probabilistic": "probabilistic.md",
+    "cca_zoo.tree": "tree.md",
+    "cca_zoo.datasets": "datasets.md",
+    "cca_zoo.model_selection": "model-selection.md",
+}
+
+
+def _documented_symbols(doc_path: Path) -> set[str]:
+    """Extract the trailing symbol name from every mkdocstrings ``::: `` line."""
+    text = doc_path.read_text()
+    refs = re.findall(r"^::: (\S+)$", text, flags=re.MULTILINE)
+    return {ref.rsplit(".", 1)[-1] for ref in refs}
+
+
+@pytest.mark.parametrize("module_name", sorted(MODULE_DOC_PAGES))
+def test_all_public_symbols_are_documented(module_name: str) -> None:
+    """Every name in a module's __all__ has a `::: ` entry in its API doc page."""
+    module = importlib.import_module(module_name)
+    public_names = getattr(module, "__all__", [])
+    if not public_names:
+        pytest.skip(
+            f"{module_name}.__all__ is empty (optional dependency not installed)"
+        )
+
+    doc_path = DOCS_API_DIR / MODULE_DOC_PAGES[module_name]
+    documented = _documented_symbols(doc_path)
+
+    missing = [name for name in public_names if name not in documented]
+    assert not missing, (
+        f"{module_name}.__all__ contains names with no docs/api/"
+        f"{MODULE_DOC_PAGES[module_name]} entry: {missing}. "
+        "Add a `::: ...` line for each, grouped under the relevant heading."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -453,7 +453,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
-    { name = "scikit-learn", specifier = ">=1.4" },
+    { name = "scikit-learn", specifier = ">=1.6" },
     { name = "scipy", specifier = ">=1.11" },
     { name = "tensorly", specifier = ">=0.8" },
     { name = "torch", marker = "extra == 'deep'", specifier = ">=2.1" },
@@ -846,7 +846,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -881,43 +881,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -2697,7 +2697,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2736,7 +2736,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2748,7 +2748,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2778,9 +2778,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2792,7 +2792,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },


### PR DESCRIPTION
## Summary

Addresses items 2-4 from the API/docs audit (item 1 — a Lightning-idiomatic `fit()` for `cca_zoo.deep` — is deliberately deferred to its own change, per discussion).

**2. Dead `_more_tags()` → real `__sklearn_tags__()`**

`cca_zoo/_base.py` and `probabilistic/_pcca.py` overrode `_more_tags()`, which sklearn 1.6+ replaced with `__sklearn_tags__()` returning a `Tags` dataclass — nothing reads the old dict anymore, so these were silent no-ops. Replaced with a real override that marks `no_validation=True`, `_skip_test=True`, and clears `input_tags.two_d_array`, honestly reflecting that `fit`/`transform`/`score` take a *list* of per-view arrays, not sklearn's standard single 2-D `X`. Deleted `ProbabilisticCCA`'s now-fully-redundant override.

Side effect I had to chase down: `sklearn.utils.Tags` only exists from sklearn **1.6** — the declared floor was `>=1.4`, which means this file was already one `import` away from breaking for anyone actually on 1.4/1.5. Bumped the floor to `>=1.6` (verified: `Tags` import fails on 1.5.2, succeeds on 1.6.0).

**3. Doctests wired into CI**

5 of the 29 collectible doctest examples (`CCA_EY`, `MCCA_EY`, `PLS_EY`, `GridSearchCV`, `_MultiviewWrapper`) were failing — each called `.fit(...)` as a bare statement, and doctest was catching the printed `repr()` as unexpected output. Fixed all 5 (assign the result, matching the convention already used elsewhere), and added a `pytest --doctest-modules` step to the CI test job, scoped to the modules importable without optional heavy deps (`linear`, `nonparametric`, `datasets`, `model_selection`) — same rationale as the existing `not slow` marker for `deep`/`tree`/`probabilistic`, which need torch/xgboost/numpyro and aren't installed in that job.

**4. Docs-coverage test instead of full auto-generation**

I'd originally suggested switching `docs/api/*.md` to auto-generated reference pages (`mkdocs-gen-files`). Looking closer, those pages aren't just a flat class list — they're hand-organized into meaningful categories (e.g. linear.md's "Two-view exact" / "Multiview" / "Confound-adjusted" / "Gradient-descent" / "Sparse-iterative" sections), and a blanket per-module auto-listing would flatten that grouping for not much practical gain, since the actual bug wasn't bad organization, it was a class occasionally going undocumented entirely.

Instead, `tests/test_docs_coverage.py` asserts every name in a module's `__all__` has a matching `::: ` entry somewhere in its `docs/api/*.md` page — a mechanical, always-on backstop for exactly the failure mode that let GRCCA/PartialCCA/DMCCA/DGCCA (and originally several v2.6.0 models) go undocumented, without giving up the curated structure. Verified it actually catches the regression (temporarily removed a `::: ` line locally, confirmed the test fails with a clear message, restored it). Happy to redo this as full `mkdocs-gen-files` generation instead if you'd rather have that.

## Test plan

- [x] `uv run pytest -m "not slow"` on 3.10/3.11/3.12 — 392 passed, 16 skipped
- [x] `uv run pytest --doctest-modules cca_zoo/{linear,nonparametric,datasets,model_selection}` — 29 passed
- [x] `tests/test_docs_coverage.py` verified to fail when a doc entry is missing, passes on current tree
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy cca_zoo` — clean
- [x] `uv run mkdocs build --strict` — succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL3GT9jTbPvuCwbvmztghe)_