### PR TITLE
Fix TreeCCA's reference to cite the actual TreeCCA paper

### DIFF
--- a/cca_zoo/tree/_treecca.py
+++ b/cca_zoo/tree/_treecca.py
@@ -190,9 +190,8 @@ class TreeCCA(BaseModel):
     generalised from two views to an arbitrary number of views.
 
     References:
-        Chapman, J., Wells, L., & Lawry Aguila, L. (2024). Unconstrained
-        stochastic CCA: Unifying multiview and self-supervised learning.
-        arXiv:2310.01012.
+        Chapman, J. (2026). TreeCCA: Canonical Correlation Analysis via
+        Gradient-Boosted Trees. arXiv:2607.27027.
 
     Args:
         latent_dimensions: Number of latent components. Must not exceed the

--- a/docs/user-guide/tree.md
+++ b/docs/user-guide/tree.md
@@ -107,5 +107,5 @@ Hyperparameters are best selected by cross-validation with `GridSearchCV` from
   initialisation draws that many orthogonal directions in feature space).
 - Unlike `KCCA`, `TreeCCA` does not store the training data for inference — new data is passed
   directly through the fitted boosters, so `transform` on held-out data is inexpensive.
-- Reference: Chapman, J., Wells, L., & Lawry Aguila, L. (2024). *Unconstrained stochastic CCA:
-  Unifying multiview and self-supervised learning.* arXiv:2310.01012.
+- Reference: Chapman, J. (2026). *TreeCCA: Canonical Correlation Analysis via
+  Gradient-Boosted Trees.* arXiv:2607.27027.


### PR DESCRIPTION
## Summary

`TreeCCA` was citing arXiv:2310.01012 (Chapman, Wells & Lawry Aguila 2024, "Unconstrained stochastic CCA" — the general EY-objective paper, which is correctly still cited separately in `_utils/_ey.py` for the shared EY machinery it's built on). TreeCCA itself now has its own paper; updated both the class docstring and `docs/user-guide/tree.md` to cite it:

> Chapman, J. (2026). TreeCCA: Canonical Correlation Analysis via Gradient-Boosted Trees. arXiv:2607.27027.

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy cca_zoo` — clean
- [x] `uv run pytest --doctest-modules cca_zoo/tree` / `pytest tests/tree -m slow` — pass
- [x] `uv run mkdocs build --strict` — succeeds; manually confirmed the citation renders correctly on both the built API reference page and the user guide page

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL3GT9jTbPvuCwbvmztghe)_