### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-Everything below has landed on `main` since the `v3.0.0` tag but has not yet been released
-to PyPI.
+## [3.1.0] - 2026-08-03
 
 ### Added
 
@@ -54,6 +53,8 @@ to PyPI.
 - `README.md` rewritten to reflect the current method list, install instructions, and
   badges.
 - Every public class's docstring now includes a literature `References:` section.
+- Project logo and favicon replaced with a hand-authored two-ring mark (previously a large
+  auto-traced SVG); the favicon is now a proper multi-resolution `.ico` generated from it.
 
 ### Removed
 
@@ -67,6 +68,9 @@ to PyPI.
 - Redundant hand-written `get_params`/`set_params` roundtrip tests, now that
   `tests/test_sklearn_compat.py` covers every model generically.
 - `.readthedocs.yaml` (dead Sphinx config; docs are built with MkDocs).
+- Unused favicon-generator output (`favicon-16x16.png`, `favicon-32x32.png`,
+  `apple-touch-icon.png`, `android-chrome-*.png`, `site.webmanifest`) — never referenced by
+  `mkdocs.yml`, `README.md`, or the built site.
 
 ## [3.0.0] - 2026-03-07
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cca-zoo"
-version = "3.0.0"
+version = "3.1.0"
 description = "Multiview CCA methods in a scikit-learn style framework"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "cca-zoo"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Releases everything accumulated on `main` since `v3.0.0`:

- `CCAR3`, `TreeCCA` (new models)
- `GRCCA`, `PartialCCA`, `DMCCA`, `DGCCA` restored from v2.6.0
- sklearn-compat validation (`_parameter_constraints`) and generic `estimator_checks` coverage
- Doc/math rendering fixes across the whole site
- `uv`-based dependency management (`dependency-groups`, committed `uv.lock`)
- New hand-authored logo + regenerated favicon
- Dead `examples/`, `benchmark/`, `.readthedocs.yaml`, and unused favicon-generator files removed

All additive/non-breaking, so this is a minor bump: `3.0.0` → `3.1.0`. Moves `CHANGELOG.md`'s `Unreleased` section to `[3.1.0] - 2026-08-03` and reopens an empty `Unreleased` section, and syncs `uv.lock`'s embedded project version.

Note: this PR only bumps the version and updates the changelog. Tagging `v3.1.0` (which triggers the PyPI publish via CI) is a separate, deliberate step after this merges.

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy cca_zoo` — clean (52 source files)
- [x] `uv run pytest -m "not slow"` — 481 passed
- [x] `uv run mkdocs build --strict` — succeeds
- [x] `uv lock` — resolves cleanly, only the embedded project version changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL3GT9jTbPvuCwbvmztghe)_