### PR TITLE
Fix CCAR3 ADMM solver returning the wrong variable, breaking lambda_

### DIFF
--- a/cca_zoo/linear/_ccar3.py
+++ b/cca_zoo/linear/_ccar3.py
@@ -68,7 +68,16 @@ def _admm_row_sparse_rrr(
         dual = np.linalg.norm(Z_old - Z) / np.sqrt(p)
         if max(primal, dual) < tol:
             break
-    return np.asarray(B)
+    # Return Z, not B: Z is the variable the group soft-threshold above was
+    # actually applied to, so it has exact zero rows by construction. B is
+    # only the smooth (unconstrained) ADMM working variable -- it merely
+    # converges *towards* Z within `tol` in aggregate (Frobenius) norm, so
+    # individual rows of B are generically still nonzero (just small) even
+    # once the primal/dual residual check has passed at the default
+    # tol=1e-4, which made `lambda_` appear to have no effect on sparsity
+    # at that default. Returning Z fixes this without depending on how
+    # tight `tol` happens to be.
+    return np.asarray(Z)
 
 
 def _postprocess_rrr_fit(

--- a/tests/linear/test_eigendecomposition.py
+++ b/tests/linear/test_eigendecomposition.py
@@ -635,6 +635,29 @@ def test_ccar3_sparsity_zeroes_rows(two_views: list[np.ndarray]) -> None:
     assert np.any(row_norms > 1e-2)
 
 
+def test_ccar3_sparsity_at_default_tol(correlated_views: list[np.ndarray]) -> None:
+    """Regression test: the ADMM solver must return the row-thresholded
+    variable (Z), not the smooth working variable (B), or `lambda_` has no
+    effect on sparsity at the default `tol=1e-4` -- B only converges
+    *towards* Z within `tol` in an aggregate Frobenius sense, so individual
+    rows of B stay generically nonzero (just small) well past that
+    tolerance, while Z has exact zero rows by construction of the group
+    soft-threshold applied to it. Uses the library's default `tol`
+    deliberately, unlike test_ccar3_sparsity_zeroes_rows above (tol=1e-8):
+    that tighter tolerance can mask this bug by converging B close enough
+    to Z anyway.
+    """
+    dense = CCAR3(latent_dimensions=2, lambda_=0.0, ledoit_wolf=False).fit(correlated_views)
+    sparse = CCAR3(latent_dimensions=2, lambda_=0.05, ledoit_wolf=False).fit(correlated_views)
+
+    dense_row_norms = np.linalg.norm(dense.weights_[0], axis=1)
+    sparse_row_norms = np.linalg.norm(sparse.weights_[0], axis=1)
+
+    assert np.all(dense_row_norms > 1e-8), "lambda_=0 should not zero any rows"
+    assert np.any(sparse_row_norms == 0.0), "a moderate lambda_ should zero some rows exactly"
+    assert np.any(sparse_row_norms > 1e-8), "and leave others exactly as nonzero"
+
+
 def test_ccar3_score_shape(two_views: list[np.ndarray]) -> None:
     """CCAR3's score returns an array of shape (latent_dimensions,)."""
     k = 2

--- a/tests/linear/test_eigendecomposition.py
+++ b/tests/linear/test_eigendecomposition.py
@@ -636,25 +636,30 @@ def test_ccar3_sparsity_zeroes_rows(two_views: list[np.ndarray]) -> None:
 
 
 def test_ccar3_sparsity_at_default_tol(correlated_views: list[np.ndarray]) -> None:
-    """Regression test: the ADMM solver must return the row-thresholded
-    variable (Z), not the smooth working variable (B), or `lambda_` has no
-    effect on sparsity at the default `tol=1e-4` -- B only converges
-    *towards* Z within `tol` in an aggregate Frobenius sense, so individual
-    rows of B stay generically nonzero (just small) well past that
-    tolerance, while Z has exact zero rows by construction of the group
-    soft-threshold applied to it. Uses the library's default `tol`
-    deliberately, unlike test_ccar3_sparsity_zeroes_rows above (tol=1e-8):
-    that tighter tolerance can mask this bug by converging B close enough
-    to Z anyway.
+    """Regression test for the ADMM solver's returned variable.
+
+    The solver must return the row-thresholded variable (Z), not the smooth
+    working variable (B), or `lambda_` has no effect on sparsity at the
+    default `tol=1e-4` -- B only converges *towards* Z within `tol` in an
+    aggregate Frobenius sense, so individual rows of B stay generically
+    nonzero (just small) well past that tolerance, while Z has exact zero
+    rows by construction of the group soft-threshold applied to it. Uses the
+    library's default `tol` deliberately, unlike test_ccar3_sparsity_zeroes_rows
+    above (tol=1e-8): that tighter tolerance can mask this bug by converging
+    B close enough to Z anyway.
     """
-    dense = CCAR3(latent_dimensions=2, lambda_=0.0, ledoit_wolf=False).fit(correlated_views)
-    sparse = CCAR3(latent_dimensions=2, lambda_=0.05, ledoit_wolf=False).fit(correlated_views)
+    dense = CCAR3(latent_dimensions=2, lambda_=0.0, ledoit_wolf=False).fit(
+        correlated_views
+    )
+    sparse = CCAR3(latent_dimensions=2, lambda_=0.05, ledoit_wolf=False).fit(
+        correlated_views
+    )
 
     dense_row_norms = np.linalg.norm(dense.weights_[0], axis=1)
     sparse_row_norms = np.linalg.norm(sparse.weights_[0], axis=1)
 
     assert np.all(dense_row_norms > 1e-8), "lambda_=0 should not zero any rows"
-    assert np.any(sparse_row_norms == 0.0), "a moderate lambda_ should zero some rows exactly"
+    assert np.any(sparse_row_norms == 0.0), "a moderate lambda_ should zero some rows"
     assert np.any(sparse_row_norms > 1e-8), "and leave others exactly as nonzero"
 
 


### PR DESCRIPTION
## Summary

- `_admm_row_sparse_rrr` in `cca_zoo/linear/_ccar3.py` returned `B`, the smooth ADMM working variable, instead of `Z`, the variable the group soft-threshold is actually applied to.
- `B` only converges *towards* `Z` within `tol` in an aggregate (Frobenius-norm) sense, so individual rows of `B` stay generically nonzero — just small — well past the library's default `tol=1e-4`. In practice this meant `lambda_` had no visible effect on row sparsity across several orders of magnitude at the default tolerance (verified: sweeping `lambda_` from 0 to 100 on synthetic data left `weights_[0]` fully dense throughout), even though the internal `Z` was correctly sparse the entire time.
- Fix: return `Z` instead of `B`. `Z` is exactly row-sparse by construction of the group soft-threshold, so this doesn't depend on how tight `tol` happens to be, unlike an absolute post-hoc threshold would.

## How I found this

While benchmarking CCAR3 as a sparse-CCA baseline, sweeping `lambda_` produced identical (dense) output across a huge range. I traced it by calling `_admm_row_sparse_rrr` directly and instrumenting the loop: at convergence, the internal `Z` had 0 nonzero rows (correctly sparse), but the returned `B` had all rows above `1e-8` in magnitude.

I then compared against the reference R implementation this module is a port of (`jameschapman19/ccar3`, `R/group_reduced_rank_regression.R::solve_group_rrr_admm`). It hits the identical underlying issue and works around it with a post-hoc absolute threshold before returning:
```r
B_opt <- B
B_opt[abs(B_opt) < thresh_0] <- 0
return(B_opt)
```
Returning `Z` directly is a more robust fix than replicating that threshold in Python: `Z` is exactly sparse by construction regardless of `tol`, whereas an absolute magic-constant threshold (`thresh_0`) depends on the data's scale and could zero true small-but-real signal or fail to zero noise at a different scale.

Two secondary things I checked while comparing against the R source and want to flag rather than silently fix or ignore, in case they're intentional:
- R's group threshold multiplies by `sqrt(group size)` (`lambda * sqrt(length(idx)) / rho`). This is a non-issue for this port specifically, since every "group" here is a single row (size 1, `sqrt(1)=1`), so the formulas already coincide — flagging only in case a future PR adds real multi-row groups (e.g. one-hot-encoded categorical blocks), where this would then matter.
- R's group-ADMM residual check uses raw `norm(Z-B)`, not normalized by `sqrt(p)`, while this Python version (and its own plain-lasso sibling `solve_rrr_admm`) does normalize. I left this as-is since the `sqrt(p)`-normalized version seems like the more principled design (tolerance comparable across different `p`), and it isn't the cause of the sparsity bug — just noting the discrepancy for the record.

## Test plan

- [x] Added `test_ccar3_sparsity_at_default_tol`, which fits at the library's *default* `tol=1e-4` (the existing `test_ccar3_sparsity_zeroes_rows` uses `tol=1e-8`, tight enough to mask this bug by converging `B` close enough to `Z` anyway) and asserts some rows become *exactly* zero. Verified it fails on the pre-fix code (`git stash` the fix, rerun) and passes after.
- [x] Full existing suite: `pytest tests/ -q` → 481 passed, 6 skipped (unrelated skips), no regressions.
- [x] Manual sweep of `lambda_` from 0 to 10 on synthetic data now shows a proper graduated sparsity path (`nnz`: 50 → 43 → 1 → 0) instead of being stuck at 50 throughout.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NoaVbNM7aj6aRhYJM6ubW8)_