### PR TITLE
Bump version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-08-04
+
 ### Added
 
 - `GFA` (Group Factor Analysis): a third probabilistic CCA backend, ported faithfully from the
@@ -74,6 +76,17 @@ project adheres to [Semantic Versioning](https://semver.org/).
   The blended gradient is verified against finite differences and, at its `c=0`/`c=1` endpoints,
   against bit-for-bit exact matches with the pre-existing unregularised EY gradient and with
   `PLS_EY`'s own independently verified gradient.
+- `CCAR3`'s ADMM row-sparse solver returned `B`, the smooth ADMM working variable, instead of
+  `Z`, the variable its group soft-threshold is actually applied to. `B` only converges
+  *towards* `Z` within `tol` in an aggregate Frobenius sense, so individual rows of `B` stay
+  generically nonzero (just small) well past the default `tol=1e-4` — meaning `lambda_` had no
+  visible effect on row sparsity across several orders of magnitude at the library's own
+  default tolerance, even though `Z` was correctly sparse throughout. Verified against the
+  reference R implementation (`jameschapman19/ccar3`), which hits the same issue and works
+  around it with a post-hoc absolute threshold; returning `Z` directly is more robust since it's
+  exactly sparse by construction regardless of how tight `tol` happens to be. Added a regression
+  test at the library's default `tol` (the pre-existing sparsity test used `tol=1e-8`, tight
+  enough to mask the bug).
 
 ## [3.1.0] - 2026-08-03
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cca-zoo"
-version = "3.1.0"
+version = "3.2.0"
 description = "Multiview CCA methods in a scikit-learn style framework"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "cca-zoo"
-version = "3.1.0"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Releases everything accumulated on `main` since `v3.1.0`:

- `VariationalBayesCCA`, `GFA` (new probabilistic CCA backends)
- `log_likelihood()` on `GFA`, `ProbabilisticCCA`, `VariationalBayesCCA`
- Fix: `ProbabilisticCCA.score()`/`.get_factor_loadings()` returning wrong values for joint-latent models
- Fix: `ProbabilisticCCA.weights_` biased toward zero by unaligned posterior rotations across NUTS draws
- Fix: `CCA_EY`/`MCCA_EY` whitening the full dataset up front instead of operating on raw mini-batches; `c` reworked into a ridge blend towards `PLS_EY`; `PLS_EY` now a thin `CCA_EY` subclass
- Fix: `CCAR3`'s ADMM solver returning the smooth working variable instead of the actually-sparse one, so `lambda_` had no visible effect on sparsity at the default `tol`

Also adds the `CHANGELOG.md` entry for the `CCAR3` fix (#225), which was merged without one, and moves `Unreleased` to `[3.2.0] - 2026-08-04`, reopening an empty `Unreleased` section — same pattern as #223.

All additive/non-breaking at the API level (no signature changes), so this is a minor bump: `3.1.0` → `3.2.0`.

Note: this PR only bumps the version and updates the changelog/lockfile. Tagging `v3.2.0` (which triggers the PyPI publish via CI) is a separate, deliberate step after this merges.

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy cca_zoo` — clean (55 source files)
- [x] `uv run pytest -m "not slow"` — 513 passed, 4 skipped
- [x] `uv run pytest --doctest-modules cca_zoo` — 51 passed
- [x] `uv run mkdocs build --strict` — succeeds
- [x] `uv lock` — resolves cleanly, only the embedded project version changed
- [x] `uv run pytest -m slow` (deep/probabilistic/tree extras synced) — 71 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL3GT9jTbPvuCwbvmztghe)_