### PR TITLE
Make release process robust: hatch-vcs, release-triggered publish, environment gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ["v*"]
   pull_request:
     branches: [main]
+  release:
+    types: [published]
 
 jobs:
   # -------------------------------------------------------------------------
@@ -16,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the package version from git tag history; a
+          # shallow/no-tags checkout falls back to a "0.1.dev..." version
+          # rather than failing, but every job should still see the real one.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -44,6 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the package version from git tag history; a
+          # shallow/no-tags checkout falls back to a "0.1.dev..." version
+          # rather than failing, but every job should still see the real one.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -75,6 +86,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the package version from git tag history; a
+          # shallow/no-tags checkout falls back to a "0.1.dev..." version
+          # rather than failing, but every job should still see the real one.
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -116,6 +132,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the package version from git tag history; a
+          # shallow/no-tags checkout falls back to a "0.1.dev..." version
+          # rather than failing, but every job should still see the real one.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -153,6 +174,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the package version from git tag history; a
+          # shallow/no-tags checkout falls back to a "0.1.dev..." version
+          # rather than failing, but every job should still see the real one.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -171,25 +197,37 @@ jobs:
         run: uv run mkdocs build --strict
 
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
 
 # -------------------------------------------------------------------------
-# Publish job (triggered by version tags)
+# Publish job (triggered by a published GitHub Release, not a raw tag push —
+# drafting a Release is the deliberate human act that should gate publishing).
+# Requires a "pypi" GitHub Environment (Settings > Environments) with
+# required reviewers configured for a manual approval gate in addition to
+# this workflow's own condition; create it there since environment
+# protection rules aren't settable from a workflow file.
 # -------------------------------------------------------------------------
   publish:
     name: Publish to PyPI
-    needs: [lint, typecheck, test]
+    needs: [lint, typecheck, test, test-slow, docs]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' && github.event.action == 'published'
+    environment:
+      name: pypi
+      url: https://pypi.org/project/cca-zoo/
     permissions:
       id-token: write  # OIDC Trusted Publishing — no API secrets needed
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the package version from the release's git tag;
+          # a shallow checkout would silently ship the wrong version instead.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -200,9 +238,18 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Build
+        run: uv build
+
+      - name: Verify the release tag matches the built package version
         run: |
-          uv pip install --system hatchling
-          python -m hatchling build
+          sdist="$(ls dist/*.tar.gz)"
+          built_version="$(basename "$sdist" .tar.gz | sed 's/^cca_zoo-//')"
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$built_version" != "$tag_version" ]; then
+            echo "::error::Release tag 'v$tag_version' does not match the version hatch-vcs derived from git history ('$built_version', from $sdist). Refusing to publish." >&2
+            exit 1
+          fi
+          echo "Publishing cca-zoo $built_version for tag $GITHUB_REF_NAME"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# hatch-vcs writes this at build time from the current git tag; never commit it.
+cca_zoo/_version.py
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- The package version is now derived from git tags (`hatch-vcs`) instead of a hand-maintained
+  `version = "..."` string in `pyproject.toml`. This closes the exact failure mode that
+  motivated it: a tag and the shipped version silently disagreeing because someone forgot the
+  bump-version PR (or the version happened not to be on PyPI yet, in which case the mismatch
+  would previously have published *permanently* under the wrong number). Version-bump PRs going
+  forward only need to move `CHANGELOG.md`'s `Unreleased` section into a dated one — there's no
+  version field left to edit. Verified: a checkout at a tagged commit builds exactly that
+  version; any other commit builds a `<last-tag>.dev<N>+g<hash>` version; a shallow/no-tags
+  checkout falls back to a `0.1.dev...` version rather than failing the build outright.
+- The PyPI publish job now triggers on a GitHub *Release* being published, not a raw
+  `git push --tags`. Drafting a Release (`gh release create` or the UI) is a more deliberate,
+  visible act than pushing a tag, and is also the trigger most current guidance recommends for
+  Trusted Publishing. The job also now runs behind a `pypi` GitHub Environment for an
+  independent required-reviewer approval gate — **the environment itself must still be created
+  with a required reviewer under Settings > Environments**, since protection rules aren't
+  configurable from a workflow file.
+- Added a publish-job step that re-derives the version from the built sdist's filename and
+  compares it to the release tag, failing loudly (before any upload) if they disagree, as a
+  second, independent check behind the `hatch-vcs`/tag-based versioning above.
+- `CITATION.cff`'s `version`/`date-released` fields were stale at `3.0.0` (never updated across
+  the `3.1.0` or `3.2.0` releases) — bumped to match. These fields can't be derived automatically
+  (Zenodo metadata, not a build artifact), so they stay a manual step in the release checklist.
+
 ## [3.2.0] - 2026-08-04
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
   given-names: "Johannes"
 
 title: "CCA-Zoo"
-version: 3.0.0
+version: 3.2.0
 doi: 10.5281/zenodo.4382739
-date-released: 2026-03-07
+date-released: 2026-08-04
 url: "https://github.com/jameschapman19/cca_zoo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "cca-zoo"
-version = "3.2.0"
+dynamic = ["version"]
 description = "Multiview CCA methods in a scikit-learn style framework"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -49,6 +49,12 @@ Documentation = "https://jameschapman19.github.io/cca_zoo/"
 
 [dependency-groups]
 dev = ["cca-zoo[dev]"]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "cca_zoo/_version.py"
 
 [tool.ruff]
 line-length = 88

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,6 @@ wheels = [
 
 [[package]]
 name = "cca-zoo"
-version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -439,16 +438,20 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "arviz", marker = "extra == 'all'", specifier = ">=0.17" },
     { name = "arviz", marker = "extra == 'probabilistic'", specifier = ">=0.17" },
-    { name = "cca-zoo", extras = ["deep", "probabilistic", "tree"], marker = "extra == 'all'" },
+    { name = "jax", marker = "extra == 'all'", specifier = ">=0.4" },
     { name = "jax", marker = "extra == 'probabilistic'", specifier = ">=0.4" },
+    { name = "lightgbm", marker = "extra == 'all'", specifier = ">=4.0" },
     { name = "lightgbm", marker = "extra == 'tree'", specifier = ">=4.0" },
+    { name = "lightning", marker = "extra == 'all'", specifier = ">=2.1" },
     { name = "lightning", marker = "extra == 'deep'", specifier = ">=2.1" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5,<2.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5,<10.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "numpyro", marker = "extra == 'all'", specifier = ">=0.13" },
     { name = "numpyro", marker = "extra == 'probabilistic'", specifier = ">=0.13" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5" },
@@ -456,10 +459,12 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.6" },
     { name = "scipy", specifier = ">=1.11" },
     { name = "tensorly", specifier = ">=0.8" },
+    { name = "torch", marker = "extra == 'all'", specifier = ">=2.1" },
     { name = "torch", marker = "extra == 'deep'", specifier = ">=2.1" },
+    { name = "xgboost", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "xgboost", marker = "extra == 'tree'", specifier = ">=2.0" },
 ]
-provides-extras = ["deep", "probabilistic", "tree", "dev", "docs", "all"]
+provides-extras = ["all", "deep", "dev", "docs", "probabilistic", "tree"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "cca-zoo", extras = ["dev"] }]


### PR DESCRIPTION
## Summary

Following up on the `pyproject.toml` version bump (#226): `version = "..."` was a hand-maintained string that could drift from the git tag that actually triggers a publish. If the tag didn't match the toml version *and* that version hadn't been published yet (e.g. tagging before merging the bump PR), the mismatch would ship **permanently** under the wrong number — PyPI never lets you reuse a version, even after yanking.

This implements the standard modern-Python-package fix for that class of problem:

- **`hatch-vcs`**: the version is now derived from git tag history at build time instead of a static field. There's no field left to forget to bump — version-bump PRs going forward only touch `CHANGELOG.md` (moving `Unreleased` to a dated section). Verified locally:
  - A clean checkout exactly at a tag (`v3.2.0`) builds exactly `3.2.0`.
  - Any other commit builds `<last-tag>.devN+g<hash>` (e.g. `3.1.1.dev11+g...`).
  - A shallow/no-tags checkout falls back to `0.1.dev...` rather than failing the build outright (confirmed against a `--depth 1 --no-tags` clone).
  - Added `fetch-depth: 0` to every job's checkout so the version each job sees is meaningful, not just the fallback.
- **Publish trigger moved from a raw tag push to a published GitHub Release.** Drafting a Release is a more deliberate, visible act than `git push --tags`, and it's the trigger current Trusted Publishing guidance recommends. The publish job now also runs behind a `pypi` GitHub Environment for an independent required-reviewer approval gate.

  ⚠️ **Manual step needed**: create the `pypi` environment under **Settings → Environments** with a required reviewer — protection rules aren't configurable from a workflow file, so this PR can wire the reference to it but can't create it.
- **Belt-and-suspenders check**: a new publish-job step rebuilds with `uv build`, reads the version back out of the built sdist's filename, and compares it to the release tag — failing loudly *before* any upload if they disagree, independent of whether `hatch-vcs` itself is working correctly.
- `publish`'s `needs:` now includes `test-slow` and `docs` (previously just `lint`/`typecheck`/`test`), so a release re-runs the *entire* suite against the exact tagged commit before publishing, not just the subset that happened to gate the old tag-push trigger.
- Fixed `CITATION.cff`'s `version`/`date-released`, stale at `3.0.0` since before the `3.1.0`/`3.2.0` releases (can't be derived automatically — Zenodo metadata, not a build artifact — so it's called out as a manual release-checklist item in the changelog).

## Test plan

- [x] `uv build` at a clean checkout of a locally-created `v3.2.0` tag → produces exactly `cca_zoo-3.2.0.tar.gz`/`.whl`; deleted the local-only tag afterward, nothing pushed
- [x] `uv build` at other commits → produces `cca_zoo-<tag>.devN+g<hash>...` as expected
- [x] `uv build` in a `--depth 1 --no-tags` clone → falls back to `0.1.dev...`, does not error
- [x] Manually verified the publish job's new bash comparison step both rejects a mismatch and accepts a match
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy cca_zoo` — clean (56 source files, matching the typecheck job's exact `--group dev`-only environment)
- [x] `uv run pytest -m "not slow"` (matching the `test` job's exact environment) — 505 passed, 7 skipped (optional-extra-gated)
- [x] `uv run pytest --doctest-modules cca_zoo` — 51 passed
- [x] `uv run mkdocs build --strict` — succeeds
- [x] `uv lock --check` — lockfile still consistent with `pyproject.toml`
- [x] Workflow YAML parses (`yaml.safe_load`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL3GT9jTbPvuCwbvmztghe)_