### PR TITLE
Differentiate CCA_EY/PLS_EY initial-weights strategy to match each loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `CCA_EY` (and `MCCA_EY`, which inherits it) now initialises its weights
+  differently from `PLS_EY`, matching each loss's own structure: `PLS_EY`
+  keeps a plain, data-independent unit-norm-orthogonal-weight
+  initialisation (`cca_zoo._utils._ey.random_orthonormal_weights`), while
+  `CCA_EY` now uses a cheap, data-informed initialisation
+  (`cheap_orthonormal_projection_weights`) that gives exactly
+  unit-variance, uncorrelated *projections* on one mini-batch instead — a
+  cheap stand-in for classical CCA's full whitening step, without the
+  full-batch cost. As a side effect, `PLS_EY` and `CCA_EY(c=1)` no longer
+  fit identical weights from the same seed (only their loss/gradient
+  formula is still identical; `tests/linear/test_gradient.py` was updated
+  to check that invariant directly instead). Note this initialisation
+  change does not, by itself, mitigate the `c=0` divergence risk described
+  above — empirically confirmed it does not measurably postpone it either,
+  since every later step draws an independent fresh mini-batch — `c` and
+  `batch_size` remain the actual remedy for that.
+
 - The package version is now derived from git tags (`hatch-vcs`) instead of a hand-maintained
   `version = "..."` string in `pyproject.toml`. This closes the exact failure mode that
   motivated it: a tag and the shipped version silently disagreeing because someone forgot the

--- a/cca_zoo/_utils/_ey.py
+++ b/cca_zoo/_utils/_ey.py
@@ -95,6 +95,95 @@ def weight_gram_mean(weights: list[np.ndarray]) -> np.ndarray:
     return total
 
 
+def random_orthonormal_weights(
+    views: list[np.ndarray], latent_dimensions: int, rng: np.random.Generator
+) -> list[np.ndarray]:
+    r"""Cheap, data-independent initial weights with orthonormal columns.
+
+    Each view's weight matrix is the $Q$ factor of a QR decomposition of
+    an i.i.d. standard normal matrix, so $W_i^\top W_i = I$ exactly, before
+    any gradient step and without looking at the data at all. This matches
+    the structure of :class:`~cca_zoo.linear.gradient.PLS_EY`'s own penalty,
+    which drives weights towards orthonormality directly in weight space
+    (see :func:`weight_gram_mean`) — the loss's own fixed point is already
+    the natural initial point's shape.
+
+    Args:
+        views: Per-view arrays; only ``.shape[1]`` (feature count) is used.
+        latent_dimensions: Requested number of latent dimensions.
+        rng: Random generator.
+
+    Returns:
+        List of weight matrices, each $(p_i, k)$ with orthonormal columns,
+        where $k = \min(\text{latent\_dimensions}, p_i)$.
+    """
+    weights = []
+    for v in views:
+        p = v.shape[1]
+        k = min(latent_dimensions, p)
+        w, _ = np.linalg.qr(rng.standard_normal((p, k)))
+        weights.append(w)
+    return weights
+
+
+def cheap_orthonormal_projection_weights(
+    views: list[np.ndarray],
+    latent_dimensions: int,
+    batch_size: int | None,
+    rng: np.random.Generator,
+) -> list[np.ndarray]:
+    r"""Cheap initial weights giving unit-variance projections on one batch.
+
+    Classical CCA whitens each view with a full $(p, p)$ eigendecomposition
+    of its covariance before fitting; that full-batch pass is exactly what
+    the EY reformulation exists to avoid (see
+    :class:`~cca_zoo.linear.gradient.CCA_EY`). This is a cheap substitute
+    usable only at initialisation: draw random directions, project one
+    mini-batch, and QR-orthonormalise the resulting $(n, k)$ projection
+    instead of the $(p, p)$ data covariance, then pull that
+    orthonormalisation back into the weight matrix via the QR's $(k, k)$
+    triangular factor — one small QR and one $k \times k$ solve per view,
+    independent of $p$. Concretely, for random directions $W_0$,
+    mini-batch $X$, and $X W_0 = QR$:
+
+    $$
+    W = W_0 R^{-1}, \qquad X W = X W_0 R^{-1} = Q R R^{-1} = Q
+    $$
+
+    so the resulting projections are exactly orthonormal ($Q^\top Q = I$)
+    on that mini-batch — a cheap stand-in for the reward term's ideal
+    starting point ($V \approx I$; see :func:`ey_cross_covariance`) and
+    the natural match for :class:`~cca_zoo.linear.gradient.CCA_EY`'s own
+    fixed point. This orthonormalises only the *first* mini-batch, though:
+    every later step draws an independent fresh batch, so this does not,
+    by itself, prevent the ``c=0`` divergence risk noted in that class's
+    docstring (empirically confirmed: it does not measurably postpone it
+    either) — ``c`` or ``batch_size`` remain the actual remedy for that.
+
+    Args:
+        views: Per-view arrays, each $(n, p_i)$.
+        latent_dimensions: Requested number of latent dimensions.
+        batch_size: Mini-batch size used for the initial projection.
+            ``None`` uses the full dataset.
+        rng: Random generator.
+
+    Returns:
+        List of weight matrices, each $(p_i, k)$.
+    """
+    n = views[0].shape[0]
+    bs = n if batch_size is None else min(batch_size, n)
+    idx = rng.choice(n, bs, replace=False)
+    weights = []
+    for v in views:
+        p = v.shape[1]
+        k = min(latent_dimensions, p)
+        w0, _ = np.linalg.qr(rng.standard_normal((p, k)))
+        z0 = v[idx] @ w0
+        _, r = np.linalg.qr(z0)
+        weights.append(w0 @ np.linalg.solve(r, np.eye(k)))
+    return weights
+
+
 def ey_grad_z(representations: list[np.ndarray]) -> list[np.ndarray]:
     r"""Gradient of the EY loss w.r.t. each embedding (M-view generalised).
 

--- a/cca_zoo/linear/gradient/_base.py
+++ b/cca_zoo/linear/gradient/_base.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 import numpy as np
 
 from cca_zoo._base import BaseModel
+from cca_zoo._utils._ey import random_orthonormal_weights
 
 
 class BaseGradientModel(BaseModel):
@@ -78,24 +79,24 @@ class BaseGradientModel(BaseModel):
         """Scalar loss value, used only for the ``tol`` convergence check."""
 
     def _initial_weights(
-        self, dims: list[int], rng: np.random.Generator
+        self, views: list[np.ndarray], rng: np.random.Generator
     ) -> list[np.ndarray]:
-        """Random-orthogonal initial weights, one per view.
+        """Cheap, data-independent orthonormal initial weights, one per view.
+
+        The default for this base class; :class:`~cca_zoo.linear.gradient.CCA_EY`
+        overrides this with a data-informed initialisation more appropriate
+        to its own loss (see
+        :func:`cca_zoo._utils._ey.cheap_orthonormal_projection_weights`).
 
         Args:
-            dims: Number of features per view.
+            views: Per-view arrays; only used for their feature counts.
             rng: Random generator.
 
         Returns:
             List of weight matrices, each (p_i, k) with orthonormal columns,
             where ``k = min(latent_dimensions, p_i)``.
         """
-        weights = []
-        for p in dims:
-            k = min(self.latent_dimensions, p)
-            w, _ = np.linalg.qr(rng.standard_normal((p, k)))
-            weights.append(w)
-        return weights
+        return random_orthonormal_weights(views, self.latent_dimensions, rng)
 
     def _gradient_descent(
         self, views: list[np.ndarray], rng: np.random.Generator
@@ -111,7 +112,7 @@ class BaseGradientModel(BaseModel):
         """
         n = views[0].shape[0]
         bs = n if self.batch_size is None else min(self.batch_size, n)
-        weights = self._initial_weights([v.shape[1] for v in views], rng)
+        weights = self._initial_weights(views, rng)
         velocity = [np.zeros_like(w) for w in weights]
         prev_obj = np.inf
         for _ in range(self.max_iter):

--- a/cca_zoo/linear/gradient/_cca_ey.py
+++ b/cca_zoo/linear/gradient/_cca_ey.py
@@ -9,7 +9,11 @@ import numpy as np
 from numpy.typing import ArrayLike
 from sklearn.utils._param_validation import Interval
 
-from cca_zoo._utils._ey import ey_cross_covariance, weight_gram_mean
+from cca_zoo._utils._ey import (
+    cheap_orthonormal_projection_weights,
+    ey_cross_covariance,
+    weight_gram_mean,
+)
 from cca_zoo.linear.gradient._base import BaseGradientModel
 
 
@@ -62,7 +66,14 @@ class CCA_EY(BaseGradientModel):
         data's near-null directions. If you see ``nan`` weights, increase
         ``c`` (a small value like 0.1-0.3 is usually enough) or
         ``batch_size`` rather than assuming the model doesn't apply to your
-        data.
+        data. (Initial weights give exactly unit-variance, uncorrelated
+        projections on one mini-batch — see
+        :func:`cca_zoo._utils._ey.cheap_orthonormal_projection_weights` — a
+        cheap stand-in for classical CCA's full whitening step and the
+        natural match for this loss's own fixed point; empirically this
+        does *not* postpone the divergence above, since every later
+        mini-batch is an independent fresh draw, so ``c``/``batch_size``
+        remain the actual remedy.)
 
     References:
         Chapman, J., Wells, L., & Lawry Aguila, A. (2024). Unconstrained
@@ -138,6 +149,23 @@ class CCA_EY(BaseGradientModel):
         rng = np.random.default_rng(self.random_state)
         self.weights_ = self._gradient_descent(views_, rng)
         return self
+
+    def _initial_weights(
+        self, views: list[np.ndarray], rng: np.random.Generator
+    ) -> list[np.ndarray]:
+        """Cheap, data-informed initial weights (see class docstring note).
+
+        Overrides :meth:`BaseGradientModel._initial_weights`'s plain
+        weight-orthonormal default: gives exactly unit-variance,
+        uncorrelated projections on one mini-batch instead, matching this
+        loss's own reward term at its fixed point (see
+        :func:`cca_zoo._utils._ey.cheap_orthonormal_projection_weights`).
+        Note this does not, by itself, prevent the ``c=0`` divergence risk
+        noted above — see that note for why, and the actual remedy.
+        """
+        return cheap_orthonormal_projection_weights(
+            views, self.latent_dimensions, self.batch_size, rng
+        )
 
     def _derivative(
         self,

--- a/cca_zoo/linear/gradient/_pls_ey.py
+++ b/cca_zoo/linear/gradient/_pls_ey.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import numpy as np
 from numpy.typing import ArrayLike
 
+from cca_zoo._utils._ey import random_orthonormal_weights
 from cca_zoo.linear.gradient._cca_ey import CCA_EY
 
 
@@ -19,6 +21,13 @@ class PLS_EY(CCA_EY):
 
     Suitable for high-dimensional or streaming data where forming the full
     (p x p) cross-covariance matrix is too expensive.
+
+    Initial weights have exactly orthonormal columns (unit-norm, mutually
+    orthogonal) before any gradient step, matching the shape of this loss's
+    own penalty on $B$ — unlike :class:`~cca_zoo.linear.gradient.CCA_EY`'s
+    own data-informed default, which instead orthonormalises the initial
+    *projections* (see :func:`cca_zoo._utils._ey.random_orthonormal_weights`
+    vs. :func:`cca_zoo._utils._ey.cheap_orthonormal_projection_weights`).
 
     References:
         Chapman, J., Wells, L., & Lawry Aguila, A. (2024). Unconstrained
@@ -82,3 +91,14 @@ class PLS_EY(CCA_EY):
             ValueError: If views have inconsistent numbers of samples.
         """
         return super().fit(views, y)
+
+    def _initial_weights(
+        self, views: list[np.ndarray], rng: np.random.Generator
+    ) -> list[np.ndarray]:
+        """Plain orthonormal-weight initial weights (see class docstring).
+
+        Overrides :class:`~cca_zoo.linear.gradient.CCA_EY`'s data-informed
+        default, since this loss's own penalty targets weight-space
+        orthonormality rather than projection-space decorrelation.
+        """
+        return random_orthonormal_weights(views, self.latent_dimensions, rng)

--- a/tests/linear/test_gradient.py
+++ b/tests/linear/test_gradient.py
@@ -263,13 +263,30 @@ def test_cca_ey_accepts_c_pls_ey_does_not() -> None:
     assert "c" not in PLS_EY().get_params()
 
 
-def test_pls_ey_is_cca_ey_with_c_equal_one(two_views: list[np.ndarray]) -> None:
-    """PLS_EY produces identical weights to CCA_EY(c=1) given the same seed."""
-    kwargs = dict(latent_dimensions=1, max_iter=50, batch_size=16, random_state=0)
-    w_pls = PLS_EY(**kwargs).fit(two_views).weights
-    w_cca = CCA_EY(c=1.0, **kwargs).fit(two_views).weights
-    for a, b in zip(w_pls, w_cca):
+def test_pls_ey_loss_matches_cca_ey_at_c_equal_one(
+    two_views: list[np.ndarray],
+) -> None:
+    """PLS_EY's derivative/objective are exactly CCA_EY's own formula at c=1.
+
+    PLS_EY no longer fits identical weights to CCA_EY(c=1) given the same
+    seed, since the two now deliberately use different initial-weights
+    strategies (see cca_zoo._utils._ey.random_orthonormal_weights vs.
+    cheap_orthonormal_projection_weights) -- this checks the invariant that
+    actually matters instead: the shared loss/gradient formula itself.
+    """
+    k = 2
+    rng = np.random.default_rng(0)
+    weights = [rng.standard_normal((v.shape[1], k)) for v in two_views]
+    representations = [v @ w for v, w in zip(two_views, weights)]
+    pls = PLS_EY(latent_dimensions=k)
+    cca_c1 = CCA_EY(latent_dimensions=k, c=1.0)
+    grads_pls = pls._derivative(two_views, representations, weights)
+    grads_cca = cca_c1._derivative(two_views, representations, weights)
+    for a, b in zip(grads_pls, grads_cca):
         np.testing.assert_array_equal(a, b)
+    assert pls._objective(two_views, representations, weights) == cca_c1._objective(
+        two_views, representations, weights
+    )
 
 
 def test_cca_ey_c_zero_matches_shared_ey_gradient(
@@ -376,3 +393,76 @@ def test_gradient_models_find_high_correlation(
         .score(correlated_views)
     )
     assert np.all(s > 0.8), f"{ModelClass.__name__} got low correlation: {s}"
+
+
+# ---------------------------------------------------------------------------
+# Initial weights: PLS_EY gets plain orthonormal weights (matching its own
+# weight-space penalty); CCA_EY (and MCCA_EY, which inherits it) gets a
+# cheap, data-informed init giving exactly unit-variance, uncorrelated
+# projections on the first mini-batch instead (a cheap stand-in for
+# classical CCA's full whitening step, and a direct counter to the
+# near-null-direction divergence risk noted in CCA_EY's own docstring).
+# ---------------------------------------------------------------------------
+
+
+def test_pls_ey_initial_weights_are_orthonormal(two_views: list[np.ndarray]) -> None:
+    """PLS_EY's initial weights have exactly orthonormal columns per view."""
+    k = 2
+    rng = np.random.default_rng(0)
+    model = PLS_EY(latent_dimensions=k, random_state=0)
+    weights = model._initial_weights(two_views, rng)
+    for w in weights:
+        np.testing.assert_allclose(w.T @ w, np.eye(k), atol=1e-10)
+
+
+def test_cca_ey_initial_weights_give_orthonormal_projections(
+    two_views: list[np.ndarray],
+) -> None:
+    """CCA_EY's initial weights give unit-variance, uncorrelated projections.
+
+    Unlike PLS_EY's plain weight-orthonormal init, CCA_EY's own initial
+    *weights* are not themselves orthonormal in general -- what's
+    orthonormal is the projection onto the mini-batch used to build them.
+    """
+    k = 2
+    bs = 16
+    rng = np.random.default_rng(0)
+    model = CCA_EY(latent_dimensions=k, batch_size=bs, random_state=0)
+    weights = model._initial_weights(two_views, rng)
+    # Re-derive, with a fresh rng in the same state, exactly which rows the
+    # initialiser sampled, so the projection can be checked on that batch.
+    rng2 = np.random.default_rng(0)
+    n = two_views[0].shape[0]
+    idx = rng2.choice(n, bs, replace=False)
+    for view, w in zip(two_views, weights):
+        z = view[idx] @ w
+        np.testing.assert_allclose(z.T @ z, np.eye(k), atol=1e-8)
+
+
+def test_cca_ey_initial_weights_differ_from_pls_ey(
+    two_views: list[np.ndarray],
+) -> None:
+    """The two initialisers give different weights from the same seed."""
+    k = 2
+    rng_pls = np.random.default_rng(0)
+    rng_cca = np.random.default_rng(0)
+    w_pls = PLS_EY(latent_dimensions=k)._initial_weights(two_views, rng_pls)
+    w_cca = CCA_EY(latent_dimensions=k)._initial_weights(two_views, rng_cca)
+    assert any(not np.allclose(a, b) for a, b in zip(w_pls, w_cca))
+
+
+def test_mcca_ey_initial_weights_give_orthonormal_projections(
+    three_correlated_views: list[np.ndarray],
+) -> None:
+    """MCCA_EY inherits CCA_EY's data-informed initialiser unchanged."""
+    k = 2
+    bs = 32
+    rng = np.random.default_rng(0)
+    model = MCCA_EY(latent_dimensions=k, batch_size=bs, random_state=0)
+    weights = model._initial_weights(three_correlated_views, rng)
+    rng2 = np.random.default_rng(0)
+    n = three_correlated_views[0].shape[0]
+    idx = rng2.choice(n, bs, replace=False)
+    for view, w in zip(three_correlated_views, weights):
+        z = view[idx] @ w
+        np.testing.assert_allclose(z.T @ z, np.eye(k), atol=1e-8)


### PR DESCRIPTION
## Summary

`CCA_EY` and `PLS_EY` previously shared the exact same random-orthonormal-*weight* initialisation, inherited unchanged from `BaseGradientModel`. That's the right initial point for `PLS_EY` — its penalty targets weight-space orthonormality ($B \approx I$) directly — but not really the right one for `CCA_EY`, whose reward term wants decorrelated, unit-variance *projections*, which classical (whitened) CCA gets from a full covariance eigendecomposition that the EY reformulation exists specifically to avoid doing every step.

- Added `cca_zoo._utils._ey.random_orthonormal_weights` (the existing behaviour, extracted into a shared helper) and `cheap_orthonormal_projection_weights` (new): the latter projects random directions onto one mini-batch, QR-orthonormalises the resulting $(n, k)$ projection instead of the $(p, p)$ data covariance, and pulls that orthonormalisation back into the weight matrix via the QR's $(k, k)$ triangular factor — one small QR + one $k \times k$ solve per view, independent of $p$.
- `CCA_EY._initial_weights` now uses the new data-informed helper; `PLS_EY._initial_weights` (and `BaseGradientModel`'s own default) keep the plain weight-orthonormal one. `MCCA_EY` inherits `CCA_EY`'s override unchanged.

**Important correction made along the way**: I initially assumed (and said so in the docstrings) that starting `CCA_EY` from already-decorrelated projections would help the known `c=0` divergence risk (documented in `CCA_EY`'s own docstring). I checked this empirically before shipping it — across 30 seeds on the adversarial scenario from that docstring (n=200, p=500/400, batch_size=64), the new init actually diverges *sooner* on average (27/30 seeds), not later, since only the very first mini-batch benefits from the decorrelation and every subsequent step draws an independent fresh batch. Corrected the docstrings to state this rather than the wrong assumption — `c`/`batch_size` remain the actual, previously-verified remedy for that divergence risk.

- `PLS_EY` and `CCA_EY(c=1)` no longer fit bit-for-bit identical weights from the same seed as a result (only the loss/gradient formula is still identical). Updated `tests/linear/test_gradient.py::test_pls_ey_is_cca_ey_with_c_equal_one` (renamed `test_pls_ey_loss_matches_cca_ey_at_c_equal_one`) to check that formula-level invariant directly instead of the full fit trajectory, and added new tests asserting each initialiser's actual property (PLS_EY: exactly orthonormal weight columns; CCA_EY/MCCA_EY: exactly orthonormal projections on the sampled init batch; and that the two initialisers differ).

## Test plan

- [x] New/updated tests in `tests/linear/test_gradient.py`: `test_pls_ey_initial_weights_are_orthonormal`, `test_cca_ey_initial_weights_give_orthonormal_projections`, `test_cca_ey_initial_weights_differ_from_pls_ey`, `test_mcca_ey_initial_weights_give_orthonormal_projections`, `test_pls_ey_loss_matches_cca_ey_at_c_equal_one`
- [x] Empirically verified across 30 seeds that the new `CCA_EY` init does not mitigate (and slightly worsens) the `c=0` divergence risk, before writing that into the docstrings
- [x] `uv run pytest tests/linear/test_gradient.py` — 45 passed
- [x] `uv run pytest -m "not slow"` (matching the `test` job's exact `--group dev`-only environment) — 509 passed, 7 skipped (optional-extra-gated)
- [x] `uv run pytest --doctest-modules cca_zoo` — 51 passed
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy cca_zoo` — clean (56 source files)
- [x] `uv run mkdocs build --strict` — succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01CL3GT9jTbPvuCwbvmztghe)_