### PR TITLE
Fix SCCA_PMD's bisection to be scale-invariant

### DIFF
--- a/cca_zoo/linear/_iterative.py
+++ b/cca_zoo/linear/_iterative.py
@@ -229,25 +229,51 @@ class PLS_ALS(_BaseIterative):
 
 
 def _bisect_threshold(x: np.ndarray, l1_bound: float) -> np.ndarray:
-    """Find the soft threshold that achieves ||soft_threshold(x, delta)||_1 = l1_bound.
+    """Find the soft threshold that makes the L2-normalised thresholded
+    vector's L1 norm equal ``l1_bound``.
 
-    Uses bisection.  If ||x||_1 <= l1_bound no thresholding is applied.
+    ``l1_bound`` (``tau * sqrt(p)``, see :class:`SCCA_PMD`) is only a
+    meaningful constraint on a *unit-L2-norm* vector: ``||w||_1 <= sqrt(p)``
+    for ``||w||_2 = 1`` is the Cauchy-Schwarz bound the ``tau in (0, 1]``
+    parameterisation relies on. The bisection therefore has to search on
+    the L1/L2 ratio of the thresholded vector, ``||soft_threshold(x,
+    delta)||_1 / ||soft_threshold(x, delta)||_2``, not on
+    ``||soft_threshold(x, delta)||_1`` alone: that ratio is invariant to
+    the overall scale of ``x`` (scaling ``x`` by any ``c > 0`` scales the
+    optimal ``delta`` by the same ``c`` and leaves the ratio unchanged),
+    whereas the raw L1 norm is not. ``x`` here is an un-normalised
+    power-iteration update whose scale depends on the data
+    (:meth:`SCCA_PMD._update_weight` passes ``views[i].T @ target``,
+    typically :math:`O(\\sqrt{n})` in magnitude for standardised data),
+    not on ``tau``, so comparing that raw L1 norm directly against
+    ``l1_bound`` made the constraint's effective strength depend on the
+    data's scale rather than only on ``tau`` -- in the regime where the
+    raw update's magnitude exceeds ``l1_bound`` (the common case for
+    reasonably-sized ``n``), it made ``tau`` bind far more aggressively
+    than intended, up to and including ``tau=1`` (nominally "no sparsity
+    constraint") still producing near-maximal sparsity.
 
     Args:
-        x: Input vector.
-        l1_bound: Target L1 norm.
+        x: Input vector (un-normalised).
+        l1_bound: Target L1 norm of the L2-normalised result, in
+            ``(0, sqrt(len(x))]``.
 
     Returns:
-        Soft-thresholded vector with L2-normalised result.
+        Soft-thresholded, L2-normalised vector.
     """
-    if np.linalg.norm(x, 1) <= l1_bound:
-        return np.asarray(x / np.linalg.norm(x))
+    norm_x = np.linalg.norm(x)
+    if norm_x <= 1e-12:
+        return np.zeros_like(x)
+    unit_x = x / norm_x
+    if np.linalg.norm(unit_x, 1) <= l1_bound:
+        return np.asarray(unit_x)
     lo, hi = 0.0, np.abs(x).max()
     for _ in range(50):
         mid = (lo + hi) / 2.0
         thresholded = soft_threshold(x, mid)
-        l1 = np.linalg.norm(thresholded, 1)
-        if l1 > l1_bound:
+        norm_t = np.linalg.norm(thresholded)
+        l1_over_l2 = np.linalg.norm(thresholded, 1) / norm_t if norm_t > 1e-12 else 0.0
+        if l1_over_l2 > l1_bound:
             lo = mid
         else:
             hi = mid

--- a/tests/linear/test_iterative.py
+++ b/tests/linear/test_iterative.py
@@ -186,6 +186,53 @@ def test_scca_pmd_achieves_sparsity(two_views: list[np.ndarray]) -> None:
         assert n_zeros > 0, f"Expected some zero weights, got {n_zeros}"
 
 
+def test_scca_pmd_invariant_to_input_scale(two_views: list[np.ndarray]) -> None:
+    """SCCA_PMD's fitted weights (up to sign) must not depend on the
+    overall scale of the input data -- tau is the only sparsity control.
+
+    Regression test: _bisect_threshold used to compare the *unnormalised*
+    power-iteration update's L1 norm directly against l1_bound (a bound
+    that is only meaningful for a unit-L2-norm vector), so scaling the
+    input data changed the effective sparsity even at a fixed tau -- in
+    the common case where the raw update's magnitude exceeds l1_bound,
+    tau bound far more aggressively than intended, up to tau=1 (nominally
+    "no constraint") still producing near-total sparsity.
+    """
+    scaled_views = [v * 37.0 for v in two_views]
+    model_a = SCCA_PMD(latent_dimensions=1, tau=0.5, max_iter=200, random_state=0).fit(
+        two_views
+    )
+    model_b = SCCA_PMD(latent_dimensions=1, tau=0.5, max_iter=200, random_state=0).fit(
+        scaled_views
+    )
+    for w_a, w_b in zip(model_a.weights, model_b.weights):
+        # sign of the leading direction is arbitrary; align before comparing
+        sign = np.sign((w_a * w_b).sum()) or 1.0
+        np.testing.assert_allclose(w_a, sign * w_b, atol=1e-6)
+
+
+def test_scca_pmd_tau_controls_sparsity_monotonically(
+    two_views: list[np.ndarray],
+) -> None:
+    """Increasing tau must not decrease the number of selected features:
+    tau=1 bounds by the Cauchy-Schwarz maximum for a unit vector, so it
+    should recover the (denser) unconstrained solution, not one sparser
+    than a smaller tau's."""
+    taus = [0.3, 0.5, 0.7, 1.0]
+    nnz_by_tau = []
+    for tau in taus:
+        model = SCCA_PMD(
+            latent_dimensions=1, tau=tau, max_iter=200, random_state=0
+        ).fit(two_views)
+        nnz_by_tau.append(sum(int(np.sum(np.abs(w) > 1e-10)) for w in model.weights))
+    assert nnz_by_tau == sorted(nnz_by_tau), (
+        f"nnz should be non-decreasing in tau, got {dict(zip(taus, nnz_by_tau))}"
+    )
+    # tau=1 imposes no real constraint (L1 bound = sqrt(p), the max
+    # possible for a unit vector), so it must not be sparse.
+    assert nnz_by_tau[-1] == sum(v.shape[1] for v in two_views)
+
+
 def test_parkhomenko_achieves_sparsity(two_views: list[np.ndarray]) -> None:
     """ParkhomenkoCCA with positive tau produces sparse weights."""
     model = ParkhomenkoCCA(


### PR DESCRIPTION
## Summary
- `_bisect_threshold` compared the *unnormalised* power-iteration update's raw L1 norm directly against `l1_bound` (`tau * sqrt(p)`), a bound that is only meaningful for a unit-L2-norm vector (`||w||_1 <= sqrt(p)` for `||w||_2 = 1` is the Cauchy-Schwarz bound `tau in (0, 1]` relies on).
- Since the raw update's magnitude depends on the data's scale, not on `tau`, this made the effective sparsity constraint depend on the data's scale: whenever the raw update's L1 norm exceeded `l1_bound` (the common case for reasonably-sized `n`), `tau` bound far more aggressively than intended -- up to and including `tau=1` ("no sparsity constraint") still collapsing to near-total sparsity.
- Fixed by bisecting on the thresholded vector's L1/L2 *ratio* instead of its raw L1 norm, which is invariant to the overall scale of the input.

## Test plan
- [x] Added `test_scca_pmd_invariant_to_input_scale`: fits on the same data scaled by 37x and checks the recovered direction is unchanged (up to sign).
- [x] Added `test_scca_pmd_tau_controls_sparsity_monotonically`: checks nnz is non-decreasing in `tau`, and that `tau=1` (nominally unconstrained) recovers the fully dense solution.
- [x] Full suite: `511 passed, 7 skipped`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoaVbNM7aj6aRhYJM6ubW8)_