### PR TITLE
perf: skip solve_triangular's redundant finite-check in CCAR3's ADMM loop

### DIFF
--- a/cca_zoo/linear/_ccar3.py
+++ b/cca_zoo/linear/_ccar3.py
@@ -64,8 +64,18 @@ def _admm_row_sparse_rrr(
         # back/forward-substitution -- 6.4x faster at p=600 in a direct
         # benchmark, bit-identical output (verified against the previous
         # np.linalg.solve result to machine precision).
+        #
+        # check_finite=False skips solve_triangular's own default full-array
+        # NaN/Inf scan on every call, safe here because rhs and L are both
+        # derived from finite inputs (X, Y_tilde, and a Cholesky factor of a
+        # ridge-regularized PSD matrix) at every iteration -- another 2.1x
+        # on top of the above at p=200 in a direct benchmark (0.104s ->
+        # 0.049s for 2000 double-solves), bit-identical output.
         B = solve_triangular(
-            L.T, solve_triangular(L, rhs, lower=True), lower=False
+            L.T,
+            solve_triangular(L, rhs, lower=True, check_finite=False),
+            lower=False,
+            check_finite=False,
         )
         Z_old = Z
         Z = B + U


### PR DESCRIPTION
## Summary
- Follow-up to #231 (the O(p^3)->O(p^2) `solve_triangular` fix). Profiling the fixed version live (`py-spy dump` on a running grid search) showed a further chunk of the remaining time inside `solve_triangular`'s own `asarray_chkfinite` input-validation, which runs a full NaN/Inf scan on every call by default (`check_finite=True`).
- That scan is redundant here: `rhs` and `L` inside `_admm_row_sparse_rrr`'s loop are both derived from finite inputs at every iteration (`X`, `Y_tilde`, and a Cholesky factor of a ridge-regularized PSD matrix), so there's nothing for it to catch.
- Passed `check_finite=False` to both `solve_triangular` calls.

## Benchmark
- p=200, 2000 double-solves (`solve_triangular(L.T, solve_triangular(L, rhs))`): 0.104s -> 0.049s, **2.1x**, bit-identical output (`max abs diff: 0.0`).

## Test plan
- [x] `uv run python -m pytest tests/ -q --no-cov` — 513 passed, 7 skipped (no regressions)
- [x] Standalone before/after benchmark script comparing output and timing at p=200

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoaVbNM7aj6aRhYJM6ubW8)_