### PR TITLE
Fix SCCA_Span's citation and clarify it is not SpanCCA itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ z1, z2 = model.transform(test_views)  # each shape (200, 2)
 | `SCCA_PMD` | Sparse CCA via PMD (Witten 2009) | ≥2 |
 | `SCCA_ADMM` | Sparse CCA via ADMM (Suo 2017) | ≥2 |
 | `SCCA_IPLS` | Sparse CCA via iterative PLS (Mai & Zhang 2019) | ≥2 |
-| `SCCA_Span` | SpanCCA (Asteris 2016) | ≥2 |
+| `SCCA_Span` | Hard-threshold ALS inspired by SpanCCA (Asteris 2016) | ≥2 |
 | `ElasticCCA` | Elastic net regularised CCA (Waaijenborg 2008) | ≥2 |
 | `ParkhomenkoCCA` | Soft-threshold sparse CCA (Parkhomenko 2009) | ≥2 |
 | `PLS_ALS` | ALS variant of PLS (power iteration) | ≥2 |

--- a/cca_zoo/linear/_iterative.py
+++ b/cca_zoo/linear/_iterative.py
@@ -8,7 +8,7 @@ Classes:
     SCCA_PMD: Sparse CCA via Penalized Matrix Decomposition (Witten 2009).
     SCCA_ADMM: Sparse CCA via ADMM (Suo 2017).
     SCCA_IPLS: Iterative PLS with lasso penalty (Mai & Zhang 2019).
-    SCCA_Span: SpanCCA (Asteris 2016).
+    SCCA_Span: hard-thresholding ALS inspired by SpanCCA (Asteris 2016).
     ElasticCCA: Elastic net regularised CCA (Waaijenborg 2008).
     ParkhomenkoCCA: Sparse CCA via soft-thresholding (Parkhomenko 2009).
 """
@@ -650,20 +650,30 @@ class SCCA_IPLS(_BaseIterative):
 
 
 # ---------------------------------------------------------------------------
-# SCCA_Span — SpanCCA (Asteris 2016)
+# SCCA_Span — hard-thresholding ALS inspired by SpanCCA (Asteris 2016)
 # ---------------------------------------------------------------------------
 
 
 class SCCA_Span(_BaseIterative):
-    r"""SpanCCA — sparse CCA via truncated power iteration.
+    r"""Hard-thresholding ALS for sparse CCA, inspired by SpanCCA.
 
-    Solves sparse CCA by a sparse power iteration where each weight update
-    retains only the ``span`` entries with the largest absolute values.
+    Solves sparse CCA by an alternating least squares loop where each
+    weight update retains only the ``span`` entries with the largest
+    absolute values.
+
+    Note that this is an ALS-based heuristic, not a reimplementation of
+    SpanCCA's own Algorithm 1: the paper instead takes a single rank-r
+    SVD of the cross-covariance matrix up front, then draws many
+    independent random directions on the low-rank subspace, hard-
+    thresholds each one, and returns whichever independent candidate
+    scored highest -- it never alternately refines one running weight
+    vector the way this class (and every other class in this module,
+    see the module docstring) does.
 
     References:
-        Asteris, M., Khanna, R., Kyrillidis, A., & Dimakis, A. G. (2016).
-        Bilinear approaches for online learning over large feature spaces.
-        *NeurIPS 2016*. (SpanCCA algorithm).
+        Asteris, M., Kyrillidis, A., Koyejo, O., & Poldrack, R. (2016).
+        A simple and provable algorithm for sparse diagonal CCA. *ICML*,
+        *arXiv:1605.08961*.
 
     Args:
         latent_dimensions: Number of latent dimensions. Default is 1.

--- a/docs/user-guide/linear.md
+++ b/docs/user-guide/linear.md
@@ -245,8 +245,10 @@ model = ParkhomenkoCCA(latent_dimensions=2, tau=0.1, random_state=0).fit([X1, X2
 
 ### SCCA_Span
 
-Hard-thresholding retaining only the top `span` entries (Asteris 2016). Useful when the
-number of active features is known in advance.
+Hard-thresholding retaining only the top `span` entries, an ALS heuristic
+inspired by SpanCCA (Asteris 2016) rather than a reimplementation of its
+own randomized low-rank sampling algorithm. Useful when the number of
+active features is known in advance.
 
 ```python
 from cca_zoo.linear import SCCA_Span


### PR DESCRIPTION
## Summary

- `SCCA_Span`'s docstring cited "Asteris, M., Khanna, R., Kyrillidis, A., & Dimakis, A. G. (2016). Bilinear approaches for online learning over large feature spaces. NeurIPS 2016." No such paper exists under that title or author list. The actual SpanCCA paper is Asteris, Kyrillidis, Koyejo & Poldrack (2016), "A Simple and Provable Algorithm for Sparse Diagonal CCA," ICML 2016 (arXiv:1605.08961) — already cited correctly elsewhere in this repo (`docs/joss/paper.md`'s `asteris2016simple` bib entry has the right title, authors, and pages), so this looks like a citation that drifted only in this one docstring.
- Beyond the citation, `SCCA_Span`'s implementation is not actually SpanCCA: it reuses this module's shared ALS loop (alternately refining one running weight vector via hard-thresholding until convergence), whereas the paper's own Algorithm 1 is a randomized one-shot scheme — a single rank-r SVD of the cross-covariance up front, then many independent random trials on that low-rank subspace, keeping whichever one scores highest, with no alternating refinement at all.
- Kept the existing hard-thresholding ALS behavior unchanged (it's a reasonable heuristic in its own right) and reworded the docstring, module index, README, and user guide to describe it accurately as inspired by SpanCCA rather than an implementation of it.

## Test plan

- [x] `pytest tests/linear/test_iterative.py -k Span` — 13 passed (unchanged behavior)
- [x] `pytest --doctest-modules cca_zoo/linear/_iterative.py` — 7 passed
- [x] `ruff check` on the touched files — no new warnings (the 2 pre-existing warnings in this file are unrelated, in a different function, and present on `main` before this change too)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NoaVbNM7aj6aRhYJM6ubW8)_