### PR TITLE
Fix ParkhomenkoCCA's missing normalization and ElasticCCA's self-referential target

### DIFF
--- a/cca_zoo/linear/_iterative.py
+++ b/cca_zoo/linear/_iterative.py
@@ -847,7 +847,7 @@ class ElasticCCA(_BaseIterative):
         weights: list[np.ndarray],
         i: int,
     ) -> np.ndarray:
-        """Elastic net regression against sum-of-all-scores target.
+        """Elastic net regression against sum-of-other-views-scores target.
 
         Args:
             views: Current view arrays.
@@ -857,11 +857,7 @@ class ElasticCCA(_BaseIterative):
         Returns:
             Updated weight vector for view i.
         """
-        scores = np.stack([views[j] @ weights[j] for j in range(len(views))], axis=0)
-        target = scores.sum(axis=0)
-        norm = np.linalg.norm(target)
-        if norm > 1e-12:
-            target /= norm
+        target = _target_score(views, weights, i)
         reg = self._regressors[i]
         reg.fit(views[i], target)
         return cast(np.ndarray, np.atleast_1d(reg.coef_).ravel())
@@ -875,15 +871,27 @@ class ElasticCCA(_BaseIterative):
 class ParkhomenkoCCA(_BaseIterative):
     r"""Sparse CCA via soft-thresholding power iteration (Parkhomenko 2009).
 
-    Uses a fixed soft-threshold $\tau_i$ rather than the adaptive
-    bisection search of :class:`SCCA_PMD`:
+    The paper's own criterion is $K = \hat\Sigma_{XX}^{-1/2} \hat\Sigma_{XY}
+    \hat\Sigma_{YY}^{-1/2}$, with $\hat\Sigma_{XX}, \hat\Sigma_{YY}$ replaced
+    by their diagonals -- the paper states directly that sparsity is only
+    guaranteed under this diagonal approximation, not the full sample
+    covariance. Since diagonal whitening of a matrix is exactly per-column
+    standardisation, this is implemented by standardising each view to unit
+    per-feature variance once per latent dimension (on top of the existing
+    mean-centring), then running the same power iteration
+    :class:`SCCA_PMD`'s raw-covariance methods use on that standardised
+    data, with a fixed soft-threshold $\tau_i$ in place of the adaptive
+    bisection search:
 
     $$
     \mathbf{w}_i \leftarrow
-        S_{\tau_i}(X_i^\top \bar{\mathbf{s}}_{\neg i})
+        S_{\tau_i}(\tilde X_i^\top \bar{\mathbf{s}}_{\neg i})
     $$
 
-    where $S_\tau$ is the element-wise soft-threshold operator.
+    where $S_\tau$ is the element-wise soft-threshold operator and $\tilde
+    X_i$ denotes $X_i$ with each column scaled to unit variance. The final
+    weight is converted back to the original (unstandardised) feature scale
+    before being returned.
 
     References:
         Parkhomenko, E., Tritchler, D., & Beyene, J. (2009). Sparse
@@ -931,7 +939,7 @@ class ParkhomenkoCCA(_BaseIterative):
         w: list[np.ndarray],
         d: int,
     ) -> None:
-        """Set per-view tau values and run ALS.
+        """Set per-view tau values, run ALS on diagonally-whitened views.
 
         Args:
             views: Deflated view arrays.
@@ -939,7 +947,18 @@ class ParkhomenkoCCA(_BaseIterative):
             d: Current latent dimension index.
         """
         self._tau_vals = perview_parameter("tau", self.tau, 0.1, len(views))
-        super()._fit_single(views, w, d)
+        scales = [v.std(axis=0, keepdims=True) for v in views]
+        scales = [np.where(s < 1e-12, 1.0, s) for s in scales]
+        scaled_views = [v / s for v, s in zip(views, scales)]
+        super()._fit_single(scaled_views, w, d)
+        # w is in the standardised views' coordinates; convert back to the
+        # original feature scale and re-normalise to unit L2 norm, matching
+        # every other class in this module's convention.
+        for i in range(len(w)):
+            w[i] = w[i] / scales[i].ravel()
+            norm = np.linalg.norm(w[i])
+            if norm > 1e-12:
+                w[i] = w[i] / norm
 
     def _update_weight(
         self,


### PR DESCRIPTION
## Summary

- **`ParkhomenkoCCA`** computed `views[i].T @ target` directly on centered-but-unwhitened data — structurally identical to `SCCA_PMD`'s raw-covariance mechanism (soft-threshold instead of bisection), not Parkhomenko et al. (2009)'s actual method. The paper's own criterion is `K = Σxx⁻¹ᐟ² Σxy Σyy⁻¹ᐟ²` with `Σxx, Σyy` replaced by their diagonals — the paper states sparsity is only guaranteed under this diagonal approximation. Since diagonal whitening is exactly per-column standardization, fixed by standardizing each view to unit per-feature variance before the power iteration (on top of existing centering), then converting the final weight back to the original feature scale.

  Verified directly: a synthetic case with one scale-dominant, signal-free nuisance column and a true signal spread across three modest-scale columns went from **89% of the weight mass on the nuisance column** (0.997 vs 0.119 before the fix) to **correctly finding the true signal** (0.001 vs 1.706 after) — the textbook raw-covariance failure mode this class exists to avoid.

- **`ElasticCCA`**'s `_update_weight` summed scores over `range(len(views))` with no exclusion of view `i` itself, so the regression target for updating `w_i` partially depended on view `i`'s own current projection — directly contradicting the class's own docstring ("regressing each view's score against the sum of all **other** views' scores") and not matching Waaijenborg et al. (2008)'s or Wold's alternating-regression CCA algorithm, neither of which includes the view being updated in its own regression target. Fixed by reusing the module's existing `_target_score` helper (already used by `SCCA_Span` and `ParkhomenkoCCA` for exactly this "sum of other views" computation), which also simplifies the method. Numerical impact was mild in the specific synthetic cases I checked, but the code no longer contradicts its own documented algorithm.

## Test plan

- [x] `pytest tests/linear/test_iterative.py` — 94 passed (unchanged pass/fail set)
- [x] `pytest --doctest-modules cca_zoo/linear/_iterative.py` — 7 passed
- [x] `ruff check` on the touched file — no new warnings (the 2 pre-existing warnings are unrelated, in a different function)
- [x] Before/after comparison confirming `ParkhomenkoCCA` no longer picks up scale-dominant, signal-free features (see summary above)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NoaVbNM7aj6aRhYJM6ubW8)_