### PR TITLE
Add GAMCCA and GPCCA: nonlinear CCA via generalized additive models and Gaussian processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `GAMCCA`: nonlinear multiview CCA using a generalized additive model (one cubic
+  regression spline per input feature) as the per-view encoder, trained via the same
+  Eckart-Young objective as `TreeCCA` and the `*_EY` models — via alternating
+  (Gauss-Seidel) L2Boosting rather than `TreeCCA`'s tree boosting. No optional dependency
+  required. Fitted per-feature shape functions are inspectable directly via
+  `model.shape_function(view, feature, x)`. On data where the true per-feature
+  relationship is smooth, `GAMCCA` reaches a given held-out canonical correlation in far
+  fewer boosting rounds than `TreeCCA`, and generalises better at a matched round budget
+  (see `tests/gam/test_gamcca.py`'s outperformance test for a worked example).
+- `cca_zoo._utils._ey.random_orthogonal_embedding` and
+  `rescale_grads_to_target_std`: the random-orthogonal initial-embedding and
+  gradient-rescaling helpers previously private to `TreeCCA` are now shared EY-loss
+  utilities, used by both `TreeCCA` and the new `GAMCCA`.
+
 ### Changed
 
 - `CCA_EY` (and `MCCA_EY`, which inherits it) now initialises its weights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@ project adheres to [Semantic Versioning](https://semver.org/).
   (previously private to `GAMCCA`) is now a shared EY-loss utility, used by both `GAMCCA`
   (as a `Ridge`/`RidgeCV` `sample_weight`) and `GPCCA` (as a `GaussianProcessRegressor`
   per-sample `alpha`).
+- `GPCCA(n_inducing=...)`: a sparse (Deterministic Training Conditional) approximation for
+  datasets too large for exact GP inference's `O(n^3)` cost. Conditions each encoder on
+  `n_inducing` inducing points — an actual subset of the training rows, chosen via
+  `sklearn.cluster.kmeans_plusplus`'s seeding — reducing fitting to `O(n * n_inducing^2)`.
+  Kernel hyperparameters are still selected by an exact marginal-likelihood fit on just the
+  inducing rows (cheap, since there are few of them), while the working-response fit used to
+  build each round's representation always uses every training row via the DTC posterior
+  formula, so no training signal is discarded at the point it matters most. `None` (the
+  default) keeps exact inference, unchanged from GPCCA's initial release; values at or above
+  the number of training samples fall back to exact inference automatically. Verified to fit
+  in well under a second at 4,000 training samples (where exact inference is impractical)
+  while still recovering held-out correlation above 0.7 on a smooth nonlinear benchmark.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- `GAMCCA`: nonlinear multiview CCA using a generalized additive model (one cubic
-  regression spline per input feature) as the per-view encoder, trained via the same
-  Eckart-Young objective as `TreeCCA` and the `*_EY` models — via alternating
-  (Gauss-Seidel) L2Boosting rather than `TreeCCA`'s tree boosting. No optional dependency
-  required. Fitted per-feature shape functions are inspectable directly via
+- `GAMCCA`: nonlinear multiview CCA using a generalized additive model (one B-spline term
+  per input feature) as the per-view encoder, trained via the same Eckart-Young objective
+  as `TreeCCA` and the `*_EY` models — via alternating (Gauss-Seidel) L2Boosting rather
+  than `TreeCCA`'s tree boosting. Built entirely on scikit-learn's own
+  `SplineTransformer`/`Ridge` rather than a from-scratch spline implementation, so no new
+  dependency is required. Fitted per-feature shape functions are inspectable directly via
   `model.shape_function(view, feature, x)`. On data where the true per-feature
   relationship is smooth, `GAMCCA` reaches a given held-out canonical correlation in far
-  fewer boosting rounds than `TreeCCA`, and generalises better at a matched round budget
-  (see `tests/gam/test_gamcca.py`'s outperformance test for a worked example).
+  fewer (and cheaper) boosting rounds than `TreeCCA`, and generalises better at a matched
+  round budget (see `tests/gam/test_gamcca.py`'s outperformance test for a worked
+  example).
 - `cca_zoo._utils._ey.random_orthogonal_embedding` and
   `rescale_grads_to_target_std`: the random-orthogonal initial-embedding and
   gradient-rescaling helpers previously private to `TreeCCA` are now shared EY-loss

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,26 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - `GAMCCA`: nonlinear multiview CCA using a generalized additive model (one B-spline term
-  per input feature) as the per-view encoder, trained via the same Eckart-Young objective
-  as `TreeCCA` and the `*_EY` models — via alternating (Gauss-Seidel) L2Boosting rather
-  than `TreeCCA`'s tree boosting. Built entirely on scikit-learn's own
-  `SplineTransformer`/`Ridge` rather than a from-scratch spline implementation, so no new
-  dependency is required. Fitted per-feature shape functions are inspectable directly via
+  per input feature) as the per-view encoder, trained on the same Eckart-Young objective
+  as `TreeCCA` and the `*_EY` models, but fit the way GAM software such as `mgcv` fits an
+  ordinary GAM rather than by boosting: an inner P-IRLS loop takes Newton steps on the EY
+  loss (a working response built from the loss's analytic gradient and a diagonal-Hessian
+  weight, ridge-regressed onto each view's fixed B-spline basis) to convergence at fixed
+  smoothing parameters, wrapped in an outer loop that re-selects those smoothing
+  parameters via `RidgeCV`'s efficient leave-one-out cross-validation (the GCV/REML role)
+  and repeats until both levels stabilise. Unlike `TreeCCA`, which must take many small
+  shrunk boosting steps because a tree ensemble has no closed-form fit to a moving target,
+  GAMCCA has no `learning_rate` or `n_estimators` to tune — smoothing strength is chosen
+  automatically. Built entirely on scikit-learn's own `SplineTransformer`, `Ridge` and
+  `RidgeCV` rather than a from-scratch spline or Newton/GCV solver, so no new dependency
+  is required. Fitted per-feature shape functions are inspectable directly via
   `model.shape_function(view, feature, x)`. On data where the true per-feature
-  relationship is smooth, `GAMCCA` reaches a given held-out canonical correlation in far
-  fewer (and cheaper) boosting rounds than `TreeCCA`, and generalises better at a matched
-  round budget (see `tests/gam/test_gamcca.py`'s outperformance test for a worked
-  example).
-- `cca_zoo._utils._ey.random_orthogonal_embedding` and
-  `rescale_grads_to_target_std`: the random-orthogonal initial-embedding and
-  gradient-rescaling helpers previously private to `TreeCCA` are now shared EY-loss
-  utilities, used by both `TreeCCA` and the new `GAMCCA`.
+  relationship is smooth, GAMCCA reaches a higher held-out canonical correlation than
+  `TreeCCA` without any round-count tuning (see `tests/gam/test_gamcca.py`'s
+  outperformance test for a worked example).
+- `cca_zoo._utils._ey.random_orthogonal_embedding`: the random-orthogonal
+  initial-embedding helper previously private to `TreeCCA` is now a shared EY-loss
+  utility, used by both `TreeCCA` and `GAMCCA`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,24 @@ project adheres to [Semantic Versioning](https://semver.org/).
   outperformance test for a worked example).
 - `cca_zoo._utils._ey.random_orthogonal_embedding`: the random-orthogonal
   initial-embedding helper previously private to `TreeCCA` is now a shared EY-loss
-  utility, used by both `TreeCCA` and `GAMCCA`.
+  utility, used by `TreeCCA`, `GAMCCA`, and `GPCCA`.
+- `GPCCA`: nonlinear multiview CCA using a Gaussian process with a joint (non-additive)
+  ARD-RBF kernel over each view's raw feature vector as the per-view encoder, trained on
+  the same Eckart-Young objective as `TreeCCA` and `GAMCCA`. Fit with the same inner/outer
+  recipe as `GAMCCA`'s P-IRLS/GCV loop, with `GaussianProcessRegressor` standing in for
+  `Ridge`/`RidgeCV`: an inner loop takes Newton steps on the EY loss at fixed kernel
+  hyperparameters (`optimizer=None`, with the diagonal-Hessian weight passed as the GP's
+  per-sample `alpha`), wrapped in an outer loop that re-fits the kernel hyperparameters via
+  the GP's own marginal-likelihood optimisation and repeats until both levels stabilise.
+  Unlike `GAMCCA`'s additive splines, a joint GP kernel can represent a genuine interaction
+  between two features of the same view directly. As a Bayesian model, `transform(...,
+  return_std=True)` also returns each latent component's posterior standard deviation,
+  propagated through the whitening transform. Built entirely on scikit-learn's own
+  `GaussianProcessRegressor`, `RBF` and `ConstantKernel`, so no new dependency is required.
+- `cca_zoo._utils._ey.ey_diag_hessian`: the diagonal-Hessian approximation of the EY loss
+  (previously private to `GAMCCA`) is now a shared EY-loss utility, used by both `GAMCCA`
+  (as a `Ridge`/`RidgeCV` `sample_weight`) and `GPCCA` (as a `GaussianProcessRegressor`
+  per-sample `alpha`).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ z1, z2 = model.transform(test_views)  # each shape (200, 2)
 |---|---|---|
 | `TreeCCA` | Gradient-boosted-tree CCA (Eckart-Young objective) | ≥2 |
 
+### `cca_zoo.gam`
+
+| Class | Description | Views |
+|---|---|---|
+| `GAMCCA` | Generalized-additive-model CCA (Eckart-Young objective) | ≥2 |
+
 ### `cca_zoo.deep` *(requires `[deep]`)*
 
 Built on PyTorch Lightning — models are trained with a standard `lightning.Trainer`, not a

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ z1, z2 = model.transform(test_views)  # each shape (200, 2)
 |---|---|---|
 | `GAMCCA` | Generalized-additive-model CCA (Eckart-Young objective) | ≥2 |
 
+### `cca_zoo.gp`
+
+| Class | Description | Views |
+|---|---|---|
+| `GPCCA` | Gaussian-process CCA (Eckart-Young objective), with predictive uncertainty | ≥2 |
+
 ### `cca_zoo.deep` *(requires `[deep]`)*
 
 Built on PyTorch Lightning — models are trained with a standard `lightning.Trainer`, not a

--- a/cca_zoo/__init__.py
+++ b/cca_zoo/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "datasets",
     "deep",
     "gam",
+    "gp",
     "linear",
     "model_selection",
     "nonparametric",

--- a/cca_zoo/__init__.py
+++ b/cca_zoo/__init__.py
@@ -2,7 +2,7 @@
 
 A scikit-learn style library implementing a wide range of multiview
 Canonical Correlation Analysis methods including linear, kernel,
-deep learning, tree-based, and probabilistic variants.
+deep learning, tree-based, GAM-based, and probabilistic variants.
 """
 
 import importlib.metadata
@@ -12,6 +12,7 @@ __version__: str = importlib.metadata.version("cca_zoo")
 __all__ = [
     "datasets",
     "deep",
+    "gam",
     "linear",
     "model_selection",
     "nonparametric",

--- a/cca_zoo/_utils/_ey.py
+++ b/cca_zoo/_utils/_ey.py
@@ -226,15 +226,13 @@ def rescale_grads_to_target_std(
 
     The analytic EY gradient (:func:`ey_grad_z`) has magnitude $O(1/n)$
     (from its ``4 / (M (n - 1))`` prefactor), far smaller than the natural
-    scale of a per-round base learner's output — a boosted-tree leaf value,
-    or a ridge-fitted spline coefficient. Used unscaled as a functional
+    scale of a boosted-tree leaf value. Used unscaled as a functional
     gradient-boosting target, a single round would then contribute a
     negligible increment relative to the encoder's starting embedding, no
     matter the learning rate. Rescaling by one shared scalar restores a
-    well-conditioned target for that base learner, whichever form it takes
-    (:class:`~cca_zoo.tree.TreeCCA`'s trees, :class:`~cca_zoo.gam.GAMCCA`'s
-    splines). Since the same scalar is applied to every view, this changes
-    only the effective step size, not the gradient's direction or relative
+    well-conditioned target for :class:`~cca_zoo.tree.TreeCCA`'s trees.
+    Since the same scalar is applied to every view, this changes only the
+    effective step size, not the gradient's direction or relative
     cross-view magnitudes.
 
     Args:

--- a/cca_zoo/_utils/_ey.py
+++ b/cca_zoo/_utils/_ey.py
@@ -272,3 +272,72 @@ def ey_grad_z(representations: list[np.ndarray]) -> list[np.ndarray]:
     _, V = ey_cross_covariance(representations)
     scale = 4.0 / (m * (n - 1))
     return [scale * (zc @ V - total) for zc in centred]
+
+
+def ey_diag_hessian(
+    Z_i: np.ndarray,
+    V: np.ndarray,
+    n_views: int,
+    n_minus_1: int,
+    floor_percentile: float,
+) -> np.ndarray:
+    r"""Diagonal (per-sample) approximation of the EY loss's Hessian.
+
+    The exact Hessian of $\mathcal{L}_{EY}$ w.r.t. one view's embedding
+    $Z_i$ (holding the other views fixed) is
+
+    $$
+    \frac{\partial^2 \mathcal{L}_{EY}}{\partial Z_i^2}
+        = \frac{4}{M(n-1)}(V-1)\,P + \frac{8}{M^2(n-1)^2}\, Z_i Z_i^\top
+    $$
+
+    where $P = I - \tfrac1n\mathbf{1}\mathbf{1}^\top$ is the centring
+    projection (needed because the EY loss re-centres every embedding
+    internally, so it is invariant to shifting $Z_i$ by a constant — the
+    true Hessian must annihilate that direction) and $V$ is the (diagonal
+    of the) mean auto-covariance. This is an $(n, n)$ matrix — using its
+    diagonal as a per-sample weight is the same simplification every
+    P-IRLS-based GAM/GLM solver already makes (treating observations as
+    independent); the ``P`` term drops out of the diagonal (its diagonal
+    entries are all $1 - 1/n$, folded into the same additive constant as
+    the $(V-1)$ term).
+
+    That diagonal is usable directly only after floor-damping it: near the
+    loss's own well-conditioned fixed point ($V \approx 1$), the $(V-1)$
+    term vanishes and the diagonal collapses to just $Z_{i,m}^2$ for each
+    sample $m$ — the diagonal slice of a rank-1 matrix, an extremely poor
+    per-sample curvature estimate for most samples (verified empirically:
+    the per-sample ratio ``gradient / raw diagonal`` swings across several
+    orders of magnitude with sign changes). Flooring at a high percentile
+    of its own values — rather than a fixed constant, which would need
+    re-tuning for every ``(n_samples, n_views)`` combination — is a
+    self-calibrating Levenberg-Marquardt-style damping: it behaves like an
+    (approximately) uniform weight for typical samples and only lets the
+    Hessian's real signal through for high-leverage outliers.
+
+    Used by both :class:`~cca_zoo.gam.GAMCCA` (as a ``Ridge``/``RidgeCV``
+    ``sample_weight``) and :class:`~cca_zoo.gp.GPCCA` (as a
+    ``GaussianProcessRegressor`` per-sample ``alpha``, the heteroscedastic-
+    noise parameter that plays the same "how much to trust this
+    observation" role there).
+
+    Args:
+        Z_i: Current embedding for this view, shape (n_samples, k).
+        V: Current (k, k) mean auto-covariance matrix (see
+            :func:`ey_cross_covariance`).
+        n_views: Number of views, $M$.
+        n_minus_1: $n - 1$, the sample-covariance denominator.
+        floor_percentile: Percentile (0-100) of the raw diagonal used as
+            the damping floor.
+
+    Returns:
+        Array of shape (n_samples, k): positive per-sample weights, one
+        per latent component.
+    """
+    v_diag = np.diag(V)
+    a_coef = 4.0 / (n_views * n_minus_1) * (v_diag - 1.0)
+    b_coef = 8.0 / (n_views**2 * n_minus_1**2)
+    raw = a_coef[None, :] + b_coef * Z_i**2
+    floor = np.maximum(np.percentile(raw, floor_percentile, axis=0), 1e-10)
+    result: np.ndarray = np.maximum(raw, floor)
+    return result

--- a/cca_zoo/_utils/_ey.py
+++ b/cca_zoo/_utils/_ey.py
@@ -184,6 +184,70 @@ def cheap_orthonormal_projection_weights(
     return weights
 
 
+def random_orthogonal_embedding(
+    Xc: np.ndarray, k: int, rng: np.random.Generator
+) -> tuple[np.ndarray, np.ndarray]:
+    """Unit-variance random-orthogonal initial embedding and its projection.
+
+    Draws ``k`` random orthogonal directions in feature space (independent of
+    the data's principal directions) and rescales them so each initial
+    component has unit variance. The unit-variance scaling is what matters
+    for a well-conditioned, non-vanishing EY gradient from round zero;
+    orthogonality keeps the initial cross-component covariance at zero. Used
+    as the fixed starting point for nonlinear encoders trained by functional
+    gradient boosting (:class:`~cca_zoo.tree.TreeCCA`,
+    :class:`~cca_zoo.gam.GAMCCA`), which — unlike a linear map — have no
+    natural "zero" to start from.
+
+    Args:
+        Xc: Mean-centred training view, shape (n_samples, n_features).
+        k: Number of components. Must not exceed ``n_features``.
+        rng: Random generator used to draw the orthogonal directions.
+
+    Returns:
+        Tuple ``(base_margin, projection)``: ``base_margin`` has shape
+        (n_samples, k) and is the initial embedding for training;
+        ``projection`` has shape (n_features, k) and reproduces the same
+        unit-variance embedding for unseen data via ``Xc_new @ projection``.
+    """
+    n, p = Xc.shape
+    W, _ = np.linalg.qr(rng.standard_normal((p, k)))
+    Z = Xc @ W
+    scale = np.linalg.norm(Z, axis=0, keepdims=True) / np.sqrt(n - 1)
+    projection = (W / scale).astype(np.float32)
+    base_margin = (Z / scale).astype(np.float32)
+    return base_margin, projection
+
+
+def rescale_grads_to_target_std(
+    grads: list[np.ndarray], target_std: float = 0.1
+) -> list[np.ndarray]:
+    r"""Rescale a set of per-view EY gradients to a common target standard deviation.
+
+    The analytic EY gradient (:func:`ey_grad_z`) has magnitude $O(1/n)$
+    (from its ``4 / (M (n - 1))`` prefactor), far smaller than the natural
+    scale of a per-round base learner's output — a boosted-tree leaf value,
+    or a ridge-fitted spline coefficient. Used unscaled as a functional
+    gradient-boosting target, a single round would then contribute a
+    negligible increment relative to the encoder's starting embedding, no
+    matter the learning rate. Rescaling by one shared scalar restores a
+    well-conditioned target for that base learner, whichever form it takes
+    (:class:`~cca_zoo.tree.TreeCCA`'s trees, :class:`~cca_zoo.gam.GAMCCA`'s
+    splines). Since the same scalar is applied to every view, this changes
+    only the effective step size, not the gradient's direction or relative
+    cross-view magnitudes.
+
+    Args:
+        grads: One gradient array per view, each (n_samples, k).
+        target_std: Target standard deviation. Default is 0.1.
+
+    Returns:
+        List of rescaled gradients, same dtype as the input.
+    """
+    scale = max(max(float(g.std()) for g in grads), 1e-6)
+    return [g / scale * target_std for g in grads]
+
+
 def ey_grad_z(representations: list[np.ndarray]) -> list[np.ndarray]:
     r"""Gradient of the EY loss w.r.t. each embedding (M-view generalised).
 

--- a/cca_zoo/gam/__init__.py
+++ b/cca_zoo/gam/__init__.py
@@ -1,0 +1,7 @@
+"""Generalized-additive-model (GAM) nonlinear CCA methods."""
+
+from __future__ import annotations
+
+from cca_zoo.gam._gamcca import GAMCCA
+
+__all__ = ["GAMCCA"]

--- a/cca_zoo/gam/_gamcca.py
+++ b/cca_zoo/gam/_gamcca.py
@@ -1,0 +1,391 @@
+"""GAMCCA — generalized-additive-model Canonical Correlation Analysis."""
+
+from __future__ import annotations
+
+from numbers import Integral, Real
+from typing import Any, ClassVar
+
+import numpy as np
+from numpy.typing import ArrayLike
+from sklearn.utils._param_validation import Interval
+from sklearn.utils.validation import check_is_fitted
+
+from cca_zoo._base import BaseModel
+from cca_zoo._utils._ey import (
+    ey_grad_z,
+    random_orthogonal_embedding,
+    rescale_grads_to_target_std,
+)
+from cca_zoo._utils._validation import validate_views
+
+
+def _cubic_spline_basis(
+    x: np.ndarray, knots: np.ndarray, lo: float, hi: float
+) -> np.ndarray:
+    """Truncated-power cubic regression spline basis for one feature.
+
+    Args:
+        x: Feature values (already scaled to unit standard deviation),
+            shape (n_samples,).
+        knots: Interior knot locations (quantiles of the training data, in
+            the same scaled units), shape (n_knots,).
+        lo: Training-data lower bound, used to clip inputs before
+            evaluating the basis so that cubic extrapolation on unseen data
+            cannot blow up.
+        hi: Training-data upper bound (see ``lo``).
+
+    Returns:
+        Design matrix of shape (n_samples, 4 + n_knots): columns
+        ``1, x, x^2, x^3`` followed by one ``(x - knot)_+^3`` column per
+        interior knot.
+    """
+    xc = np.clip(x, lo, hi)
+    cols = [np.ones_like(xc), xc, xc**2, xc**3]
+    for knot in knots:
+        cols.append(np.clip(xc - knot, 0.0, None) ** 3)
+    return np.column_stack(cols)
+
+
+def _ridge_pinv(basis: np.ndarray, ridge: float) -> np.ndarray:
+    """Ridge pseudo-inverse of a design matrix, column-norm-preconditioned.
+
+    Cubic-spline basis columns (``x``, ``x^3``, truncated-cubic terms, ...)
+    have wildly different natural scales, so a single ``ridge`` value only
+    penalises them comparably after each column is rescaled to unit norm;
+    the returned pseudo-inverse already undoes that rescaling, so
+    ``basis @ (_ridge_pinv(basis, ridge) @ y)`` is the ridge fit of ``y`` in
+    the *original* column scale.
+
+    Args:
+        basis: Design matrix, shape (n_samples, n_basis).
+        ridge: Ridge penalty strength (applied after column-norm scaling,
+            so it is comparable across features regardless of their raw
+            scale).
+
+    Returns:
+        Pseudo-inverse matrix, shape (n_basis, n_samples).
+    """
+    col_scale = np.maximum(np.linalg.norm(basis, axis=0), 1e-8)
+    normed = basis / col_scale
+    gram = normed.T @ normed + ridge * np.eye(normed.shape[1])
+    pinv_normed = np.linalg.solve(gram, normed.T)
+    result: np.ndarray = pinv_normed / col_scale[:, None]
+    return result
+
+
+class _GamEncoder:
+    r"""Per-view additive spline encoder, fit by componentwise L2 boosting.
+
+    Each latent component is modelled as $f(x) = \\sum_j s_j(x_j)$, one
+    cubic regression spline per input feature. Every boosting round performs
+    one ridge-regularised least-squares fit of *all* per-feature spline
+    bases at once against the (rescaled) EY gradient, shrunk by
+    ``learning_rate`` and added to the running coefficients — i.e. L2Boosting
+    (Bühlmann & Yu, 2003) with a penalised additive-spline base learner, used
+    only during ``fit``.
+    """
+
+    def __init__(self, X: np.ndarray, k: int, n_knots: int, ridge: float) -> None:
+        n, p = X.shape
+        self.n = n
+        self.p = p
+        self.k = k
+        self.scales_ = np.maximum(X.std(axis=0), 1e-8)
+        scaled = X / self.scales_
+        self.lo_ = scaled.min(axis=0)
+        self.hi_ = scaled.max(axis=0)
+        quantiles = np.linspace(0.0, 1.0, n_knots + 2)[1:-1]
+        self.knots_ = [np.quantile(scaled[:, j], quantiles) for j in range(p)]
+        bases = [
+            _cubic_spline_basis(scaled[:, j], self.knots_[j], self.lo_[j], self.hi_[j])
+            for j in range(p)
+        ]
+        self.df_: int = bases[0].shape[1]
+        self._basis: np.ndarray = np.column_stack(bases)  # (n, p * df)
+        self._pinv: np.ndarray = _ridge_pinv(self._basis, ridge)  # (p * df, n)
+        self.coefs_: np.ndarray = np.zeros((p * self.df_, k))
+
+    def predict(self) -> np.ndarray:
+        """Encoder output on the training data, shape (n_samples, k)."""
+        result: np.ndarray = self._basis @ self.coefs_
+        return result
+
+    def boost(self, gradient: np.ndarray, learning_rate: float) -> None:
+        """Add one ridge-fitted, shrunk round to every feature's spline terms.
+
+        Args:
+            gradient: EY gradient for this view, shape (n_samples, k).
+            learning_rate: Shrinkage applied to this round's fit.
+        """
+        beta = self._pinv @ (-gradient)  # (p * df, k)
+        self.coefs_ += learning_rate * beta
+
+    def _basis_new(self, X: np.ndarray) -> np.ndarray:
+        scaled = X / self.scales_
+        bases = [
+            _cubic_spline_basis(scaled[:, j], self.knots_[j], self.lo_[j], self.hi_[j])
+            for j in range(self.p)
+        ]
+        return np.column_stack(bases)
+
+    def predict_new(self, X: np.ndarray) -> np.ndarray:
+        """Encoder output for arbitrary (e.g. test) data, shape (n, k)."""
+        result: np.ndarray = self._basis_new(X) @ self.coefs_
+        return result
+
+    def feature_term(self, feature_idx: int, x: np.ndarray) -> np.ndarray:
+        """Single feature's additive contribution $s_j(x_j)$ at given values.
+
+        Args:
+            feature_idx: Index of the input feature (in the centred-view
+                column order).
+            x: Raw (mean-centred) values for that feature, shape (n,).
+
+        Returns:
+            Array of shape (n, k): this feature's spline term alone, for
+            each latent component.
+        """
+        scaled = x / self.scales_[feature_idx]
+        lo, hi = self.lo_[feature_idx], self.hi_[feature_idx]
+        basis = _cubic_spline_basis(scaled, self.knots_[feature_idx], lo, hi)
+        block = slice(feature_idx * self.df_, (feature_idx + 1) * self.df_)
+        result: np.ndarray = basis @ self.coefs_[block]
+        return result
+
+
+class GAMCCA(BaseModel):
+    r"""GAMCCA — nonlinear multiview CCA with generalized-additive-model encoders.
+
+    Learns one nonlinear encoder $f_i$ per view — a generalized additive
+    model (GAM), $f_i(x) = \sum_j s_{ij}(x_{ij})$, summing one univariate
+    cubic-spline term per input feature — that jointly maximise the
+    Eckart-Young (EY) unconstrained-CCA objective:
+
+    $$
+    \mathcal{L}_{EY} = -2 \operatorname{tr}(C) + \operatorname{tr}(V V)
+    $$
+
+    where, for embeddings $Z_i = f_i(X_i)$, $C$ is the mean pairwise
+    cross-covariance (including $i = j$ terms) and $V$ the mean
+    auto-covariance across all views (see :mod:`cca_zoo._utils._ey`, the
+    same shared EY-loss machinery used by
+    :class:`~cca_zoo.linear.gradient.CCA_EY`, :class:`~cca_zoo.deep.DCCA_EY`,
+    and :class:`~cca_zoo.tree.TreeCCA`). The encoders are fit by alternating
+    (Gauss-Seidel) L2Boosting (Bühlmann & Yu, 2003): each round, for every
+    view in turn, the EY-loss gradient (rescaled to a fixed target standard
+    deviation — see :func:`cca_zoo._utils._ey.rescale_grads_to_target_std`,
+    needed since the analytic gradient's natural scale is far smaller than a
+    well-conditioned regression target) is fit, *jointly across all of that
+    view's features*, by a ridge-penalised cubic-regression-spline additive
+    model, shrunk by ``learning_rate`` and added to the running per-feature
+    coefficients — when ``gauss_seidel=True`` (default), the gradient is
+    recomputed from the freshest embeddings before moving to the next view.
+    Training starts from a random-orthogonal, unit-variance initial
+    embedding per view, as for :class:`~cca_zoo.tree.TreeCCA`.
+
+    Because each latent component decomposes exactly into one additive term
+    per input feature, the fitted shape of any feature's contribution is
+    available directly via :meth:`shape_function`, without a separate
+    interpretability method such as SHAP — and, unlike a boosted-tree
+    ensemble's step-function contributions, each term is a smooth curve
+    by construction. This smoothness is also a genuine inductive bias, not
+    just a cosmetic one: on data where the true per-feature relationship is
+    smooth, GAMCCA reaches a given held-out canonical correlation in far
+    fewer boosting rounds than :class:`~cca_zoo.tree.TreeCCA`, and can
+    generalise better at a matched round budget (see the module's test
+    suite for a worked example: a quadratic cross-view relationship where
+    GAMCCA reaches a held-out correlation TreeCCA does not reach even at 4x
+    the boosting rounds).
+
+    Note:
+        A GAM's additive structure assumes each feature contributes
+        independently; it cannot represent a genuine *interaction* between
+        two features of the same view (e.g. $x_1 x_2$) the way a
+        multivariate tree split can. If cross-view structure only shows up
+        through such interactions, expect :class:`~cca_zoo.tree.TreeCCA` to
+        do better instead.
+
+    References:
+        Bühlmann, P., & Yu, B. (2003). Boosting with the L2 loss:
+        regression and classification. Journal of the American Statistical
+        Association, 98(462), 324-339.
+
+        Chapman, J., Wells, L., & Lawry Aguila, A. (2024). Unconstrained
+        Stochastic CCA: Unifying Multiview and Self-Supervised Learning.
+        arXiv:2310.01012.
+
+    Args:
+        latent_dimensions: Number of latent components. Must not exceed the
+            number of features in any view. Default is 1.
+        center: Whether to subtract per-view column means before fitting.
+            Default is True.
+        n_estimators: Number of boosting rounds. Default is 150.
+        n_knots: Number of interior knots per feature's cubic regression
+            spline (basis dimension is ``4 + n_knots``: intercept, linear,
+            quadratic, cubic, plus one truncated-cubic term per knot).
+            Default is 3.
+        learning_rate: Boosting shrinkage applied to each round's ridge fit.
+            Default is 0.3.
+        ridge: Ridge penalty for each round's per-view spline fit, applied
+            after normalising every basis column to unit norm (so it
+            penalises all features/terms comparably regardless of their raw
+            scale). Higher values give smoother, less wiggly per-feature
+            curves at the cost of slower convergence, and are the main
+            defence against overfitting a single view's noise. Default is
+            0.1.
+        gauss_seidel: If True, re-predict view 1's embedding after updating
+            its encoder and use the fresh values when computing view 2's
+            gradient (Gauss-Seidel); if False, both gradients are computed
+            from the same stale embeddings (Jacobi). Default is True.
+        random_state: Seed for drawing the random-orthogonal initial
+            embedding. Default is 0.
+
+    Example:
+        >>> import numpy as np
+        >>> rng = np.random.default_rng(0)
+        >>> X1 = rng.standard_normal((200, 5))
+        >>> X2 = rng.standard_normal((200, 5))
+        >>> model = GAMCCA(latent_dimensions=2, n_estimators=20).fit([X1, X2])
+        >>> scores = model.transform([X1, X2])
+    """
+
+    _parameter_constraints: ClassVar[dict[str, list[Any]]] = {
+        **BaseModel._parameter_constraints,
+        "n_estimators": [Interval(Integral, 1, None, closed="left")],
+        "n_knots": [Interval(Integral, 1, None, closed="left")],
+        "learning_rate": [Interval(Real, 0, None, closed="neither")],
+        "ridge": [Interval(Real, 0, None, closed="left")],
+        "gauss_seidel": ["boolean"],
+    }
+
+    def __init__(
+        self,
+        latent_dimensions: int = 1,
+        center: bool = True,
+        n_estimators: int = 150,
+        n_knots: int = 3,
+        learning_rate: float = 0.3,
+        ridge: float = 0.1,
+        gauss_seidel: bool = True,
+        random_state: int = 0,
+    ) -> None:
+        super().__init__(latent_dimensions=latent_dimensions, center=center)
+        self.n_estimators = n_estimators
+        self.n_knots = n_knots
+        self.learning_rate = learning_rate
+        self.ridge = ridge
+        self.gauss_seidel = gauss_seidel
+        self.random_state = random_state
+
+    def fit(self, views: list[ArrayLike], y: None = None) -> GAMCCA:
+        """Fit the GAMCCA model.
+
+        Args:
+            views: List of 2 or more arrays, each (n_samples, n_features_i).
+            y: Ignored.
+
+        Returns:
+            self: Fitted estimator.
+
+        Raises:
+            ValueError: If fewer than 2 views are provided.
+            ValueError: If views have inconsistent numbers of samples.
+        """
+        views_ = self._setup_fit(views)
+        k = self.latent_dimensions
+        n_views = len(views_)
+
+        rng = np.random.default_rng(self.random_state)
+        base_margins = []
+        projections = []
+        for X in views_:
+            bm, proj = random_orthogonal_embedding(X, k, rng)
+            base_margins.append(bm)
+            projections.append(proj)
+        self._projections_: list[np.ndarray] = projections
+
+        encoders = [_GamEncoder(X, k, self.n_knots, self.ridge) for X in views_]
+
+        for _ in range(self.n_estimators):
+            representations = [
+                bm + enc.predict() for bm, enc in zip(base_margins, encoders)
+            ]
+            grads = rescale_grads_to_target_std(ey_grad_z(representations))
+
+            for view_idx in range(n_views):
+                encoders[view_idx].boost(grads[view_idx], self.learning_rate)
+                if self.gauss_seidel and view_idx < n_views - 1:
+                    representations[view_idx] = (
+                        base_margins[view_idx] + encoders[view_idx].predict()
+                    )
+                    grads = rescale_grads_to_target_std(ey_grad_z(representations))
+
+        self.encoders_: list[_GamEncoder] = encoders
+        return self
+
+    def transform(self, views: list[ArrayLike]) -> list[np.ndarray]:
+        """Project views into the latent space using the fitted encoders.
+
+        Args:
+            views: List of arrays, each (n_samples, n_features_i), matching
+                the number of views passed to ``fit``.
+
+        Returns:
+            List of arrays, each (n_samples, latent_dimensions).
+
+        Raises:
+            sklearn.exceptions.NotFittedError: If ``fit`` has not been called.
+            ValueError: If fewer than 2 views are provided.
+        """
+        check_is_fitted(self)
+        validated = validate_views(views)
+        centred = [v - m for v, m in zip(validated, self.means_)]
+        result = []
+        for v, enc, projection in zip(centred, self.encoders_, self._projections_):
+            bm = v @ projection
+            result.append(bm + enc.predict_new(v))
+        return result
+
+    def shape_function(self, view: int, feature: int, x: ArrayLike) -> np.ndarray:
+        r"""Evaluate one feature's fitted additive term $s_j(x_j)$.
+
+        Because GAMCCA's encoder is additive across features, each term can
+        be inspected in isolation — the direct GAM analogue of
+        :class:`~cca_zoo.tree.TreeCCA`'s split-gain feature importance, but
+        exact and shape-preserving rather than a single importance score.
+
+        Args:
+            view: Index of the view.
+            feature: Index of the feature within that view (raw, i.e.
+                un-centred column order).
+            x: Raw (un-centred) values for that feature at which to evaluate
+                the term, shape (n,).
+
+        Returns:
+            Array of shape (n, latent_dimensions): that feature's
+            contribution alone, for every latent component.
+
+        Raises:
+            sklearn.exceptions.NotFittedError: If ``fit`` has not been called.
+        """
+        check_is_fitted(self)
+        x_arr = np.asarray(x, dtype=float) - self.means_[view][feature]
+        return self.encoders_[view].feature_term(feature, x_arr)
+
+    @property
+    def weights(self) -> list[np.ndarray]:
+        """Not implemented for GAMCCA.
+
+        Raises:
+            sklearn.exceptions.NotFittedError: If ``fit`` has not been called.
+            NotImplementedError: GAMCCA encoders are additive splines, not
+                linear weight matrices. Use :meth:`shape_function` instead
+                to inspect a feature's fitted contribution directly.
+        """
+        check_is_fitted(self)
+        raise NotImplementedError(
+            "GAMCCA has no linear weight matrices; its encoders are "
+            "generalized additive models (one cubic spline per feature). "
+            "Use the `shape_function` method instead to inspect a fitted "
+            "feature's contribution directly."
+        )

--- a/cca_zoo/gam/_gamcca.py
+++ b/cca_zoo/gam/_gamcca.py
@@ -7,6 +7,8 @@ from typing import Any, ClassVar
 
 import numpy as np
 from numpy.typing import ArrayLike
+from sklearn.linear_model import Ridge
+from sklearn.preprocessing import SplineTransformer
 from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted
 
@@ -19,137 +21,80 @@ from cca_zoo._utils._ey import (
 from cca_zoo._utils._validation import validate_views
 
 
-def _cubic_spline_basis(
-    x: np.ndarray, knots: np.ndarray, lo: float, hi: float
-) -> np.ndarray:
-    """Truncated-power cubic regression spline basis for one feature.
-
-    Args:
-        x: Feature values (already scaled to unit standard deviation),
-            shape (n_samples,).
-        knots: Interior knot locations (quantiles of the training data, in
-            the same scaled units), shape (n_knots,).
-        lo: Training-data lower bound, used to clip inputs before
-            evaluating the basis so that cubic extrapolation on unseen data
-            cannot blow up.
-        hi: Training-data upper bound (see ``lo``).
-
-    Returns:
-        Design matrix of shape (n_samples, 4 + n_knots): columns
-        ``1, x, x^2, x^3`` followed by one ``(x - knot)_+^3`` column per
-        interior knot.
-    """
-    xc = np.clip(x, lo, hi)
-    cols = [np.ones_like(xc), xc, xc**2, xc**3]
-    for knot in knots:
-        cols.append(np.clip(xc - knot, 0.0, None) ** 3)
-    return np.column_stack(cols)
-
-
-def _ridge_pinv(basis: np.ndarray, ridge: float) -> np.ndarray:
-    """Ridge pseudo-inverse of a design matrix, column-norm-preconditioned.
-
-    Cubic-spline basis columns (``x``, ``x^3``, truncated-cubic terms, ...)
-    have wildly different natural scales, so a single ``ridge`` value only
-    penalises them comparably after each column is rescaled to unit norm;
-    the returned pseudo-inverse already undoes that rescaling, so
-    ``basis @ (_ridge_pinv(basis, ridge) @ y)`` is the ridge fit of ``y`` in
-    the *original* column scale.
-
-    Args:
-        basis: Design matrix, shape (n_samples, n_basis).
-        ridge: Ridge penalty strength (applied after column-norm scaling,
-            so it is comparable across features regardless of their raw
-            scale).
-
-    Returns:
-        Pseudo-inverse matrix, shape (n_basis, n_samples).
-    """
-    col_scale = np.maximum(np.linalg.norm(basis, axis=0), 1e-8)
-    normed = basis / col_scale
-    gram = normed.T @ normed + ridge * np.eye(normed.shape[1])
-    pinv_normed = np.linalg.solve(gram, normed.T)
-    result: np.ndarray = pinv_normed / col_scale[:, None]
-    return result
-
-
 class _GamEncoder:
-    r"""Per-view additive spline encoder, fit by componentwise L2 boosting.
+    """Per-view additive-spline encoder, fit by componentwise L2Boosting.
 
-    Each latent component is modelled as $f(x) = \\sum_j s_j(x_j)$, one
-    cubic regression spline per input feature. Every boosting round performs
-    one ridge-regularised least-squares fit of *all* per-feature spline
-    bases at once against the (rescaled) EY gradient, shrunk by
-    ``learning_rate`` and added to the running coefficients — i.e. L2Boosting
-    (Bühlmann & Yu, 2003) with a penalised additive-spline base learner, used
-    only during ``fit``.
+    Each latent component is modelled as a generalized additive model —
+    one B-spline term per input feature — using only scikit-learn's own,
+    already-required machinery: :class:`~sklearn.preprocessing.SplineTransformer`
+    builds the per-feature B-spline design matrix (one contiguous block of
+    columns per feature) and :class:`~sklearn.linear_model.Ridge` fits it,
+    rather than reimplementing either. Every boosting round fits a fresh
+    ridge regression of the (rescaled) EY gradient onto that fixed basis and
+    accumulates it, shrunk by ``learning_rate`` — i.e. L2Boosting (Bühlmann
+    & Yu, 2003) with a penalised-spline base learner, the same
+    meta-algorithm :class:`~cca_zoo.tree.TreeCCA` uses with a decision-tree
+    base learner instead. Used only during ``fit``.
     """
 
     def __init__(self, X: np.ndarray, k: int, n_knots: int, ridge: float) -> None:
-        n, p = X.shape
-        self.n = n
-        self.p = p
+        self.n, self.p = X.shape
         self.k = k
-        self.scales_ = np.maximum(X.std(axis=0), 1e-8)
-        scaled = X / self.scales_
-        self.lo_ = scaled.min(axis=0)
-        self.hi_ = scaled.max(axis=0)
-        quantiles = np.linspace(0.0, 1.0, n_knots + 2)[1:-1]
-        self.knots_ = [np.quantile(scaled[:, j], quantiles) for j in range(p)]
-        bases = [
-            _cubic_spline_basis(scaled[:, j], self.knots_[j], self.lo_[j], self.hi_[j])
-            for j in range(p)
-        ]
-        self.df_: int = bases[0].shape[1]
-        self._basis: np.ndarray = np.column_stack(bases)  # (n, p * df)
-        self._pinv: np.ndarray = _ridge_pinv(self._basis, ridge)  # (p * df, n)
-        self.coefs_: np.ndarray = np.zeros((p * self.df_, k))
+        self.ridge = ridge
+        self._spline = SplineTransformer(
+            n_knots=n_knots,
+            degree=3,
+            knots="quantile",
+            extrapolation="constant",
+            include_bias=True,
+        )
+        self._basis: np.ndarray = self._spline.fit_transform(X)
+        self.n_splines_: int = self._basis.shape[1] // self.p
+        self.coefs_: np.ndarray = np.zeros((self._basis.shape[1], k))
+        self._train_pred: np.ndarray = np.zeros((self.n, k))
 
     def predict(self) -> np.ndarray:
         """Encoder output on the training data, shape (n_samples, k)."""
-        result: np.ndarray = self._basis @ self.coefs_
-        return result
+        return self._train_pred
 
     def boost(self, gradient: np.ndarray, learning_rate: float) -> None:
-        """Add one ridge-fitted, shrunk round to every feature's spline terms.
+        """Ridge-fit the negative gradient onto the spline basis and accumulate.
 
         Args:
             gradient: EY gradient for this view, shape (n_samples, k).
             learning_rate: Shrinkage applied to this round's fit.
         """
-        beta = self._pinv @ (-gradient)  # (p * df, k)
-        self.coefs_ += learning_rate * beta
-
-    def _basis_new(self, X: np.ndarray) -> np.ndarray:
-        scaled = X / self.scales_
-        bases = [
-            _cubic_spline_basis(scaled[:, j], self.knots_[j], self.lo_[j], self.hi_[j])
-            for j in range(self.p)
-        ]
-        return np.column_stack(bases)
+        target = -gradient
+        model = Ridge(alpha=self.ridge, fit_intercept=False)
+        model.fit(self._basis, target)
+        coef = np.atleast_2d(model.coef_).T  # (n_basis, k)
+        self.coefs_ += learning_rate * coef
+        self._train_pred += learning_rate * (self._basis @ coef)
 
     def predict_new(self, X: np.ndarray) -> np.ndarray:
         """Encoder output for arbitrary (e.g. test) data, shape (n, k)."""
-        result: np.ndarray = self._basis_new(X) @ self.coefs_
+        basis = self._spline.transform(X)
+        result: np.ndarray = basis @ self.coefs_
         return result
 
     def feature_term(self, feature_idx: int, x: np.ndarray) -> np.ndarray:
-        """Single feature's additive contribution $s_j(x_j)$ at given values.
+        """Single feature's additive contribution, shape (n, k).
 
         Args:
-            feature_idx: Index of the input feature (in the centred-view
-                column order).
+            feature_idx: Index of the input feature.
             x: Raw (mean-centred) values for that feature, shape (n,).
 
         Returns:
-            Array of shape (n, k): this feature's spline term alone, for
-            each latent component.
+            Array of shape (n, k): this feature's term alone, for each
+            latent component.
         """
-        scaled = x / self.scales_[feature_idx]
-        lo, hi = self.lo_[feature_idx], self.hi_[feature_idx]
-        basis = _cubic_spline_basis(scaled, self.knots_[feature_idx], lo, hi)
-        block = slice(feature_idx * self.df_, (feature_idx + 1) * self.df_)
-        result: np.ndarray = basis @ self.coefs_[block]
+        grid = np.zeros((len(x), self.p))
+        grid[:, feature_idx] = x
+        basis = self._spline.transform(grid)
+        block = slice(
+            feature_idx * self.n_splines_, (feature_idx + 1) * self.n_splines_
+        )
+        result: np.ndarray = basis[:, block] @ self.coefs_[block]
         return result
 
 
@@ -158,7 +103,7 @@ class GAMCCA(BaseModel):
 
     Learns one nonlinear encoder $f_i$ per view — a generalized additive
     model (GAM), $f_i(x) = \sum_j s_{ij}(x_{ij})$, summing one univariate
-    cubic-spline term per input feature — that jointly maximise the
+    B-spline term per input feature — that jointly maximise the
     Eckart-Young (EY) unconstrained-CCA objective:
 
     $$
@@ -170,26 +115,34 @@ class GAMCCA(BaseModel):
     auto-covariance across all views (see :mod:`cca_zoo._utils._ey`, the
     same shared EY-loss machinery used by
     :class:`~cca_zoo.linear.gradient.CCA_EY`, :class:`~cca_zoo.deep.DCCA_EY`,
-    and :class:`~cca_zoo.tree.TreeCCA`). The encoders are fit by alternating
-    (Gauss-Seidel) L2Boosting (Bühlmann & Yu, 2003): each round, for every
-    view in turn, the EY-loss gradient (rescaled to a fixed target standard
-    deviation — see :func:`cca_zoo._utils._ey.rescale_grads_to_target_std`,
-    needed since the analytic gradient's natural scale is far smaller than a
-    well-conditioned regression target) is fit, *jointly across all of that
-    view's features*, by a ridge-penalised cubic-regression-spline additive
-    model, shrunk by ``learning_rate`` and added to the running per-feature
-    coefficients — when ``gauss_seidel=True`` (default), the gradient is
-    recomputed from the freshest embeddings before moving to the next view.
-    Training starts from a random-orthogonal, unit-variance initial
-    embedding per view, as for :class:`~cca_zoo.tree.TreeCCA`.
+    and :class:`~cca_zoo.tree.TreeCCA`). Rather than reimplementing spline
+    fitting from scratch, each encoder is built entirely from scikit-learn's
+    own, already-required machinery:
+    :class:`~sklearn.preprocessing.SplineTransformer` builds the per-feature
+    B-spline design matrix (one contiguous block of columns per feature,
+    giving the additive structure) and :class:`~sklearn.linear_model.Ridge`
+    fits it. The encoders are fit by alternating (Gauss-Seidel) L2Boosting
+    (Bühlmann & Yu, 2003): each round, for every view in turn, the EY-loss
+    gradient (rescaled to a fixed target standard deviation — see
+    :func:`cca_zoo._utils._ey.rescale_grads_to_target_std`, needed since the
+    analytic gradient's natural scale is far smaller than a well-conditioned
+    regression target) is ridge-fit onto that view's fixed spline basis,
+    shrunk by ``learning_rate`` and added to a running total — the same
+    meta-algorithm :class:`~cca_zoo.tree.TreeCCA` uses with tree base
+    learners instead of splines. With ``gauss_seidel=True`` (default), the
+    gradient is recomputed from the freshest embeddings before moving to the
+    next view. Training starts from a random-orthogonal, unit-variance
+    initial embedding per view, as for :class:`~cca_zoo.tree.TreeCCA`. No
+    optional dependency is required — everything here is already part of
+    ``cca_zoo``'s required scikit-learn dependency.
 
     Because each latent component decomposes exactly into one additive term
     per input feature, the fitted shape of any feature's contribution is
     available directly via :meth:`shape_function`, without a separate
     interpretability method such as SHAP — and, unlike a boosted-tree
-    ensemble's step-function contributions, each term is a smooth curve
-    by construction. This smoothness is also a genuine inductive bias, not
-    just a cosmetic one: on data where the true per-feature relationship is
+    ensemble's step-function contributions, each term is a smooth curve by
+    construction. This smoothness is also a genuine inductive bias, not just
+    a cosmetic one: on data where the true per-feature relationship is
     smooth, GAMCCA reaches a given held-out canonical correlation in far
     fewer boosting rounds than :class:`~cca_zoo.tree.TreeCCA`, and can
     generalise better at a matched round budget (see the module's test
@@ -206,6 +159,9 @@ class GAMCCA(BaseModel):
         do better instead.
 
     References:
+        Eilers, P. H., & Marx, B. D. (1996). Flexible smoothing with
+        B-splines and penalties. Statistical Science, 11(2), 89-121.
+
         Bühlmann, P., & Yu, B. (2003). Boosting with the L2 loss:
         regression and classification. Journal of the American Statistical
         Association, 98(462), 324-339.
@@ -220,19 +176,16 @@ class GAMCCA(BaseModel):
         center: Whether to subtract per-view column means before fitting.
             Default is True.
         n_estimators: Number of boosting rounds. Default is 150.
-        n_knots: Number of interior knots per feature's cubic regression
-            spline (basis dimension is ``4 + n_knots``: intercept, linear,
-            quadratic, cubic, plus one truncated-cubic term per knot).
-            Default is 3.
+        n_knots: Number of knots per feature's B-spline term, passed
+            straight through to ``sklearn.preprocessing.SplineTransformer(
+            n_knots=...)``. Default is 5.
         learning_rate: Boosting shrinkage applied to each round's ridge fit.
             Default is 0.3.
-        ridge: Ridge penalty for each round's per-view spline fit, applied
-            after normalising every basis column to unit norm (so it
-            penalises all features/terms comparably regardless of their raw
-            scale). Higher values give smoother, less wiggly per-feature
-            curves at the cost of slower convergence, and are the main
-            defence against overfitting a single view's noise. Default is
-            0.1.
+        ridge: Ridge penalty for each round's per-view spline fit, passed
+            straight through to ``sklearn.linear_model.Ridge(alpha=...)``.
+            Higher values give smoother, less wiggly per-feature curves at
+            the cost of slower convergence, and are the main defence
+            against overfitting a single view's noise. Default is 0.1.
         gauss_seidel: If True, re-predict view 1's embedding after updating
             its encoder and use the fresh values when computing view 2's
             gradient (Gauss-Seidel); if False, both gradients are computed
@@ -252,7 +205,7 @@ class GAMCCA(BaseModel):
     _parameter_constraints: ClassVar[dict[str, list[Any]]] = {
         **BaseModel._parameter_constraints,
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
-        "n_knots": [Interval(Integral, 1, None, closed="left")],
+        "n_knots": [Interval(Integral, 2, None, closed="left")],
         "learning_rate": [Interval(Real, 0, None, closed="neither")],
         "ridge": [Interval(Real, 0, None, closed="left")],
         "gauss_seidel": ["boolean"],
@@ -263,7 +216,7 @@ class GAMCCA(BaseModel):
         latent_dimensions: int = 1,
         center: bool = True,
         n_estimators: int = 150,
-        n_knots: int = 3,
+        n_knots: int = 5,
         learning_rate: float = 0.3,
         ridge: float = 0.1,
         gauss_seidel: bool = True,
@@ -352,7 +305,8 @@ class GAMCCA(BaseModel):
         Because GAMCCA's encoder is additive across features, each term can
         be inspected in isolation — the direct GAM analogue of
         :class:`~cca_zoo.tree.TreeCCA`'s split-gain feature importance, but
-        exact and shape-preserving rather than a single importance score.
+        an exact, shape-preserving curve rather than a single importance
+        score.
 
         Args:
             view: Index of the view.
@@ -385,7 +339,7 @@ class GAMCCA(BaseModel):
         check_is_fitted(self)
         raise NotImplementedError(
             "GAMCCA has no linear weight matrices; its encoders are "
-            "generalized additive models (one cubic spline per feature). "
+            "generalized additive models (one B-spline term per feature). "
             "Use the `shape_function` method instead to inspect a fitted "
             "feature's contribution directly."
         )

--- a/cca_zoo/gam/_gamcca.py
+++ b/cca_zoo/gam/_gamcca.py
@@ -15,74 +15,12 @@ from sklearn.utils.validation import check_is_fitted
 from cca_zoo._base import BaseModel
 from cca_zoo._utils._ey import (
     ey_cross_covariance,
+    ey_diag_hessian,
     ey_grad_z,
     ey_loss,
     random_orthogonal_embedding,
 )
 from cca_zoo._utils._validation import validate_views
-
-
-def _diag_hessian(
-    Z_i: np.ndarray,
-    V: np.ndarray,
-    n_views: int,
-    n_minus_1: int,
-    floor_percentile: float,
-) -> np.ndarray:
-    r"""Diagonal (per-sample) approximation of the EY loss's Hessian.
-
-    The exact Hessian of $\mathcal{L}_{EY}$ w.r.t. one view's embedding
-    $Z_i$ (holding the other views fixed) is
-
-    $$
-    \frac{\partial^2 \mathcal{L}_{EY}}{\partial Z_i^2}
-        = \frac{4}{M(n-1)}(V-1)\,P + \frac{8}{M^2(n-1)^2}\, Z_i Z_i^\top
-    $$
-
-    where $P = I - \tfrac1n\mathbf{1}\mathbf{1}^\top$ is the centring
-    projection (needed because the EY loss re-centres every embedding
-    internally, so it is invariant to shifting $Z_i$ by a constant — the
-    true Hessian must annihilate that direction) and $V$ is the (diagonal
-    of the) mean auto-covariance. This is an $(n, n)$ matrix — using its
-    diagonal as a per-sample weight is the same simplification every
-    P-IRLS-based GAM/GLM solver already makes (treating observations as
-    independent); the ``P`` term drops out of the diagonal (its diagonal
-    entries are all $1 - 1/n$, folded into the same additive constant as
-    the $(V-1)$ term).
-
-    That diagonal is usable directly only after floor-damping it: near the
-    loss's own well-conditioned fixed point ($V \approx 1$), the $(V-1)$
-    term vanishes and the diagonal collapses to just $Z_{i,m}^2$ for each
-    sample $m$ — the diagonal slice of a rank-1 matrix, an extremely poor
-    per-sample curvature estimate for most samples (verified empirically:
-    the per-sample ratio ``gradient / raw diagonal`` swings across several
-    orders of magnitude with sign changes). Flooring at a high percentile
-    of its own values — rather than a fixed constant, which would need
-    re-tuning for every ``(n_samples, n_views)`` combination — is a
-    self-calibrating Levenberg-Marquardt-style damping: it behaves like an
-    (approximately) uniform weight for typical samples and only lets the
-    Hessian's real signal through for high-leverage outliers.
-
-    Args:
-        Z_i: Current embedding for this view, shape (n_samples, k).
-        V: Current (k, k) mean auto-covariance matrix (see
-            :func:`cca_zoo._utils._ey.ey_cross_covariance`).
-        n_views: Number of views, $M$.
-        n_minus_1: $n - 1$, the sample-covariance denominator.
-        floor_percentile: Percentile (0-100) of the raw diagonal used as
-            the damping floor.
-
-    Returns:
-        Array of shape (n_samples, k): positive per-sample weights, one
-        per latent component.
-    """
-    v_diag = np.diag(V)
-    a_coef = 4.0 / (n_views * n_minus_1) * (v_diag - 1.0)
-    b_coef = 8.0 / (n_views**2 * n_minus_1**2)
-    raw = a_coef[None, :] + b_coef * Z_i**2
-    floor = np.maximum(np.percentile(raw, floor_percentile, axis=0), 1e-10)
-    result: np.ndarray = np.maximum(raw, floor)
-    return result
 
 
 class _GamEncoder:
@@ -99,9 +37,10 @@ class _GamEncoder:
       (P-IRLS) Newton update of the spline coefficients at the *current,
       fixed* smoothing parameter (``alphas_``): ridge-regress the working
       response $Z_i - \nabla_i / h_i$ (a Newton step on the EY loss, where
-      $\nabla_i$ is :func:`cca_zoo._utils._ey.ey_grad_z`'s gradient and $h_i$
-      the diagonal-Hessian weight from :func:`_diag_hessian`) onto the fixed
-      basis, weighted by $h_i$.
+      $\nabla_i$ is :func:`~cca_zoo._utils._ey.ey_grad_z`'s gradient and
+      $h_i$ the diagonal-Hessian weight from
+      :func:`~cca_zoo._utils._ey.ey_diag_hessian`) onto the fixed basis,
+      weighted by $h_i$.
     - :meth:`outer_step` — re-selects the smoothing parameter itself via
       :class:`~sklearn.linear_model.RidgeCV`'s efficient leave-one-out
       cross-validation (the same statistical job GCV/REML do in ``mgcv``),
@@ -162,9 +101,9 @@ class _GamEncoder:
         Args:
             Z_self: This view's current embedding, shape (n_samples, k).
             grad: EY-loss gradient for this view (see
-                :func:`cca_zoo._utils._ey.ey_grad_z`), shape (n_samples, k).
-            diag_hess: Diagonal-Hessian weights (see :func:`_diag_hessian`),
-                shape (n_samples, k).
+                :func:`~cca_zoo._utils._ey.ey_grad_z`), shape (n_samples, k).
+            diag_hess: Diagonal-Hessian weights (see
+                :func:`~cca_zoo._utils._ey.ey_diag_hessian`), shape (n_samples, k).
         """
         raw_cols = []
         models = []
@@ -279,8 +218,9 @@ class GAMCCA(BaseModel):
        repeatedly form a Newton step on $\mathcal{L}_{EY}$ for each view in
        turn — a working response $Z_i - \nabla_i / h_i$ (from the analytic
        gradient :func:`~cca_zoo._utils._ey.ey_grad_z` and a diagonal-Hessian
-       weight, see :func:`_diag_hessian`) ridge-fit onto that view's fixed
-       B-spline basis — cycling through every view until the EY loss itself
+       weight, see :func:`~cca_zoo._utils._ey.ey_diag_hessian`) ridge-fit
+       onto that view's fixed B-spline basis — cycling through every view
+       until the EY loss itself
        stops moving.
     2. **Outer (GCV-style)**: only once the inner loop has converged, re-fit
        each view's smoothing parameter with :class:`~sklearn.linear_model.RidgeCV`
@@ -355,7 +295,7 @@ class GAMCCA(BaseModel):
             between successive full passes over all views. Default is 1e-4.
         hess_floor_percentile: Percentile (0-100) of each round's raw
             diagonal-Hessian values used to floor them (see
-            :func:`_diag_hessian`). Default is 90.0.
+            :func:`~cca_zoo._utils._ey.ey_diag_hessian`). Default is 90.0.
         random_state: Seed for drawing the random-orthogonal initial
             embedding. Default is 0.
 
@@ -437,7 +377,7 @@ class GAMCCA(BaseModel):
             for i in range(n_views):
                 grad = ey_grad_z(representations)[i]
                 _, V = ey_cross_covariance(representations)
-                diag_hess = _diag_hessian(
+                diag_hess = ey_diag_hessian(
                     representations[i],
                     V,
                     n_views,
@@ -449,7 +389,7 @@ class GAMCCA(BaseModel):
 
             # Inner loop: P-IRLS Newton steps at these now-fixed smoothing
             # parameters, cycling through every view, until the EY loss
-            # itself stops moving (see _diag_hessian's docstring for why
+            # itself stops moving (see ey_diag_hessian's docstring for why
             # this, rather than raw per-sample values, is the right
             # convergence signal to track).
             prev_obj = ey_loss(representations)["objective"]
@@ -457,7 +397,7 @@ class GAMCCA(BaseModel):
                 for i in range(n_views):
                     grad = ey_grad_z(representations)[i]
                     _, V = ey_cross_covariance(representations)
-                    diag_hess = _diag_hessian(
+                    diag_hess = ey_diag_hessian(
                         representations[i],
                         V,
                         n_views,

--- a/cca_zoo/gam/_gamcca.py
+++ b/cca_zoo/gam/_gamcca.py
@@ -7,40 +7,113 @@ from typing import Any, ClassVar
 
 import numpy as np
 from numpy.typing import ArrayLike
-from sklearn.linear_model import Ridge
+from sklearn.linear_model import Ridge, RidgeCV
 from sklearn.preprocessing import SplineTransformer
 from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted
 
 from cca_zoo._base import BaseModel
 from cca_zoo._utils._ey import (
+    ey_cross_covariance,
     ey_grad_z,
+    ey_loss,
     random_orthogonal_embedding,
-    rescale_grads_to_target_std,
 )
 from cca_zoo._utils._validation import validate_views
 
 
-class _GamEncoder:
-    """Per-view additive-spline encoder, fit by componentwise L2Boosting.
+def _diag_hessian(
+    Z_i: np.ndarray,
+    V: np.ndarray,
+    n_views: int,
+    n_minus_1: int,
+    floor_percentile: float,
+) -> np.ndarray:
+    r"""Diagonal (per-sample) approximation of the EY loss's Hessian.
 
-    Each latent component is modelled as a generalized additive model —
-    one B-spline term per input feature — using only scikit-learn's own,
-    already-required machinery: :class:`~sklearn.preprocessing.SplineTransformer`
-    builds the per-feature B-spline design matrix (one contiguous block of
-    columns per feature) and :class:`~sklearn.linear_model.Ridge` fits it,
-    rather than reimplementing either. Every boosting round fits a fresh
-    ridge regression of the (rescaled) EY gradient onto that fixed basis and
-    accumulates it, shrunk by ``learning_rate`` — i.e. L2Boosting (Bühlmann
-    & Yu, 2003) with a penalised-spline base learner, the same
-    meta-algorithm :class:`~cca_zoo.tree.TreeCCA` uses with a decision-tree
-    base learner instead. Used only during ``fit``.
+    The exact Hessian of $\mathcal{L}_{EY}$ w.r.t. one view's embedding
+    $Z_i$ (holding the other views fixed) is
+
+    $$
+    \frac{\partial^2 \mathcal{L}_{EY}}{\partial Z_i^2}
+        = \frac{4}{M(n-1)}(V-1)\,P + \frac{8}{M^2(n-1)^2}\, Z_i Z_i^\top
+    $$
+
+    where $P = I - \tfrac1n\mathbf{1}\mathbf{1}^\top$ is the centring
+    projection (needed because the EY loss re-centres every embedding
+    internally, so it is invariant to shifting $Z_i$ by a constant — the
+    true Hessian must annihilate that direction) and $V$ is the (diagonal
+    of the) mean auto-covariance. This is an $(n, n)$ matrix — using its
+    diagonal as a per-sample weight is the same simplification every
+    P-IRLS-based GAM/GLM solver already makes (treating observations as
+    independent); the ``P`` term drops out of the diagonal (its diagonal
+    entries are all $1 - 1/n$, folded into the same additive constant as
+    the $(V-1)$ term).
+
+    That diagonal is usable directly only after floor-damping it: near the
+    loss's own well-conditioned fixed point ($V \approx 1$), the $(V-1)$
+    term vanishes and the diagonal collapses to just $Z_{i,m}^2$ for each
+    sample $m$ — the diagonal slice of a rank-1 matrix, an extremely poor
+    per-sample curvature estimate for most samples (verified empirically:
+    the per-sample ratio ``gradient / raw diagonal`` swings across several
+    orders of magnitude with sign changes). Flooring at a high percentile
+    of its own values — rather than a fixed constant, which would need
+    re-tuning for every ``(n_samples, n_views)`` combination — is a
+    self-calibrating Levenberg-Marquardt-style damping: it behaves like an
+    (approximately) uniform weight for typical samples and only lets the
+    Hessian's real signal through for high-leverage outliers.
+
+    Args:
+        Z_i: Current embedding for this view, shape (n_samples, k).
+        V: Current (k, k) mean auto-covariance matrix (see
+            :func:`cca_zoo._utils._ey.ey_cross_covariance`).
+        n_views: Number of views, $M$.
+        n_minus_1: $n - 1$, the sample-covariance denominator.
+        floor_percentile: Percentile (0-100) of the raw diagonal used as
+            the damping floor.
+
+    Returns:
+        Array of shape (n_samples, k): positive per-sample weights, one
+        per latent component.
+    """
+    v_diag = np.diag(V)
+    a_coef = 4.0 / (n_views * n_minus_1) * (v_diag - 1.0)
+    b_coef = 8.0 / (n_views**2 * n_minus_1**2)
+    raw = a_coef[None, :] + b_coef * Z_i**2
+    floor = np.maximum(np.percentile(raw, floor_percentile, axis=0), 1e-10)
+    result: np.ndarray = np.maximum(raw, floor)
+    return result
+
+
+class _GamEncoder:
+    r"""Per-view additive-spline encoder, fit by P-IRLS + GCV/REML-style search.
+
+    Mirrors how GAM software such as ``mgcv`` actually fits a smooth term:
+    :class:`~sklearn.preprocessing.SplineTransformer` builds the per-feature
+    B-spline design matrix (one contiguous block of columns per feature) and
+    :class:`~sklearn.linear_model.Ridge` / :class:`~sklearn.linear_model.RidgeCV`
+    do the penalised fitting, rather than either being reimplemented. Two
+    kinds of step are exposed, matching ``mgcv``'s own two nested loops:
+
+    - :meth:`inner_step` — one penalised-iteratively-reweighted-least-squares
+      (P-IRLS) Newton update of the spline coefficients at the *current,
+      fixed* smoothing parameter (``alphas_``): ridge-regress the working
+      response $Z_i - \nabla_i / h_i$ (a Newton step on the EY loss, where
+      $\nabla_i$ is :func:`cca_zoo._utils._ey.ey_grad_z`'s gradient and $h_i$
+      the diagonal-Hessian weight from :func:`_diag_hessian`) onto the fixed
+      basis, weighted by $h_i$.
+    - :meth:`outer_step` — re-selects the smoothing parameter itself via
+      :class:`~sklearn.linear_model.RidgeCV`'s efficient leave-one-out
+      cross-validation (the same statistical job GCV/REML do in ``mgcv``),
+      at whatever working response/weights the inner loop has most recently
+      converged to.
+
+    Used only during ``fit``.
     """
 
-    def __init__(self, X: np.ndarray, k: int, n_knots: int, ridge: float) -> None:
+    def __init__(self, X: np.ndarray, k: int, n_knots: int) -> None:
         self.n, self.p = X.shape
         self.k = k
-        self.ridge = ridge
         self._spline = SplineTransformer(
             n_knots=n_knots,
             degree=3,
@@ -50,31 +123,98 @@ class _GamEncoder:
         )
         self._basis: np.ndarray = self._spline.fit_transform(X)
         self.n_splines_: int = self._basis.shape[1] // self.p
-        self.coefs_: np.ndarray = np.zeros((self._basis.shape[1], k))
+        self.models_: list[Ridge] = []
+        self.alphas_: np.ndarray = np.ones(k)
+        self.whiten_: np.ndarray = np.eye(k)
+        self.raw_mean_: np.ndarray = np.zeros(k)
         self._train_pred: np.ndarray = np.zeros((self.n, k))
 
     def predict(self) -> np.ndarray:
         """Encoder output on the training data, shape (n_samples, k)."""
         return self._train_pred
 
-    def boost(self, gradient: np.ndarray, learning_rate: float) -> None:
-        """Ridge-fit the negative gradient onto the spline basis and accumulate.
+    def _update_from_raw(self, raw: np.ndarray) -> None:
+        """Whiten a raw (pre-decorrelation) prediction and cache it.
+
+        The raw per-component fit is not itself guaranteed zero-mean (the
+        basis's own intercept-like capacity is fit freely), so it is
+        explicitly re-centred here; ``raw_mean_`` is cached so
+        :meth:`predict_new` and :meth:`feature_term` apply the exact same
+        correction rather than each output silently carrying its own,
+        slightly different constant offset.
 
         Args:
-            gradient: EY gradient for this view, shape (n_samples, k).
-            learning_rate: Shrinkage applied to this round's fit.
+            raw: Raw per-component predictions, shape (n_samples, k).
         """
-        target = -gradient
-        model = Ridge(alpha=self.ridge, fit_intercept=False)
-        model.fit(self._basis, target)
-        coef = np.atleast_2d(model.coef_).T  # (n_basis, k)
-        self.coefs_ += learning_rate * coef
-        self._train_pred += learning_rate * (self._basis @ coef)
+        self.raw_mean_ = raw.mean(axis=0)
+        centred = raw - self.raw_mean_
+        cov = (centred.T @ centred) / (centred.shape[0] - 1)
+        vals, vecs = np.linalg.eigh(cov)
+        vals = np.maximum(vals, 1e-8)
+        self.whiten_ = vecs @ np.diag(vals**-0.5) @ vecs.T
+        self._train_pred = centred @ self.whiten_
+
+    def inner_step(
+        self, Z_self: np.ndarray, grad: np.ndarray, diag_hess: np.ndarray
+    ) -> None:
+        """One P-IRLS Newton update at the current, fixed ``alphas_``.
+
+        Args:
+            Z_self: This view's current embedding, shape (n_samples, k).
+            grad: EY-loss gradient for this view (see
+                :func:`cca_zoo._utils._ey.ey_grad_z`), shape (n_samples, k).
+            diag_hess: Diagonal-Hessian weights (see :func:`_diag_hessian`),
+                shape (n_samples, k).
+        """
+        raw_cols = []
+        models = []
+        for c in range(self.k):
+            working_response = Z_self[:, c] - grad[:, c] / diag_hess[:, c]
+            model = Ridge(alpha=self.alphas_[c], fit_intercept=False)
+            model.fit(self._basis, working_response, sample_weight=diag_hess[:, c])
+            models.append(model)
+            raw_cols.append(model.predict(self._basis))
+        self.models_ = models
+        self._update_from_raw(np.column_stack(raw_cols))
+
+    def outer_step(
+        self,
+        Z_self: np.ndarray,
+        grad: np.ndarray,
+        diag_hess: np.ndarray,
+        alpha_grid: np.ndarray,
+    ) -> np.ndarray:
+        """Re-select the smoothing parameter via RidgeCV's efficient LOOCV.
+
+        Args:
+            Z_self: This view's current embedding, shape (n_samples, k).
+            grad: EY-loss gradient for this view, shape (n_samples, k).
+            diag_hess: Diagonal-Hessian weights, shape (n_samples, k).
+            alpha_grid: Candidate smoothing parameters to search over.
+
+        Returns:
+            The newly selected smoothing parameter per component, shape (k,).
+        """
+        raw_cols = []
+        models = []
+        new_alphas = np.empty(self.k)
+        for c in range(self.k):
+            working_response = Z_self[:, c] - grad[:, c] / diag_hess[:, c]
+            model = RidgeCV(alphas=alpha_grid)
+            model.fit(self._basis, working_response, sample_weight=diag_hess[:, c])
+            models.append(model)
+            new_alphas[c] = model.alpha_
+            raw_cols.append(model.predict(self._basis))
+        self.models_ = models
+        self.alphas_ = new_alphas
+        self._update_from_raw(np.column_stack(raw_cols))
+        return new_alphas
 
     def predict_new(self, X: np.ndarray) -> np.ndarray:
         """Encoder output for arbitrary (e.g. test) data, shape (n, k)."""
         basis = self._spline.transform(X)
-        result: np.ndarray = basis @ self.coefs_
+        raw = np.column_stack([m.predict(basis) for m in self.models_])
+        result: np.ndarray = (raw - self.raw_mean_) @ self.whiten_
         return result
 
     def feature_term(self, feature_idx: int, x: np.ndarray) -> np.ndarray:
@@ -86,7 +226,14 @@ class _GamEncoder:
 
         Returns:
             Array of shape (n, k): this feature's term alone, for each
-            latent component.
+            latent component, after the same whitening transform applied
+            to the full encoder output. Whitening is linear, so the
+            feature-wise decomposition of the raw fit carries through
+            exactly — summing this over every feature reproduces
+            :meth:`predict` exactly — except for the overall mean
+            correction cached in ``raw_mean_``, which has no natural home
+            in any single feature (it is a property of the whole additive
+            sum) and is therefore split evenly across the ``p`` features.
         """
         grid = np.zeros((len(x), self.p))
         grid[:, feature_idx] = x
@@ -94,7 +241,8 @@ class _GamEncoder:
         block = slice(
             feature_idx * self.n_splines_, (feature_idx + 1) * self.n_splines_
         )
-        result: np.ndarray = basis[:, block] @ self.coefs_[block]
+        raw = np.column_stack([basis[:, block] @ m.coef_[block] for m in self.models_])
+        result: np.ndarray = (raw - self.raw_mean_ / self.p) @ self.whiten_
         return result
 
 
@@ -115,43 +263,62 @@ class GAMCCA(BaseModel):
     auto-covariance across all views (see :mod:`cca_zoo._utils._ey`, the
     same shared EY-loss machinery used by
     :class:`~cca_zoo.linear.gradient.CCA_EY`, :class:`~cca_zoo.deep.DCCA_EY`,
-    and :class:`~cca_zoo.tree.TreeCCA`). Rather than reimplementing spline
-    fitting from scratch, each encoder is built entirely from scikit-learn's
-    own, already-required machinery:
-    :class:`~sklearn.preprocessing.SplineTransformer` builds the per-feature
-    B-spline design matrix (one contiguous block of columns per feature,
-    giving the additive structure) and :class:`~sklearn.linear_model.Ridge`
-    fits it. The encoders are fit by alternating (Gauss-Seidel) L2Boosting
-    (Bühlmann & Yu, 2003): each round, for every view in turn, the EY-loss
-    gradient (rescaled to a fixed target standard deviation — see
-    :func:`cca_zoo._utils._ey.rescale_grads_to_target_std`, needed since the
-    analytic gradient's natural scale is far smaller than a well-conditioned
-    regression target) is ridge-fit onto that view's fixed spline basis,
-    shrunk by ``learning_rate`` and added to a running total — the same
-    meta-algorithm :class:`~cca_zoo.tree.TreeCCA` uses with tree base
-    learners instead of splines. With ``gauss_seidel=True`` (default), the
-    gradient is recomputed from the freshest embeddings before moving to the
-    next view. Training starts from a random-orthogonal, unit-variance
-    initial embedding per view, as for :class:`~cca_zoo.tree.TreeCCA`. No
-    optional dependency is required — everything here is already part of
-    ``cca_zoo``'s required scikit-learn dependency.
+    and :class:`~cca_zoo.tree.TreeCCA`).
 
-    Because each latent component decomposes exactly into one additive term
-    per input feature, the fitted shape of any feature's contribution is
-    available directly via :meth:`shape_function`, without a separate
-    interpretability method such as SHAP — and, unlike a boosted-tree
-    ensemble's step-function contributions, each term is a smooth curve by
-    construction. This smoothness is also a genuine inductive bias, not just
-    a cosmetic one: on data where the true per-feature relationship is
-    smooth, GAMCCA reaches a given held-out canonical correlation in far
-    fewer boosting rounds than :class:`~cca_zoo.tree.TreeCCA`, and can
-    generalise better at a matched round budget (see the module's test
-    suite for a worked example: a quadratic cross-view relationship where
-    GAMCCA reaches a held-out correlation TreeCCA does not reach even at 4x
-    the boosting rounds).
+    Unlike those models, which reach the EY loss's optimum by many small
+    (stochastic-)gradient steps, GAMCCA fits it the way GAM software such as
+    ``mgcv`` fits an ordinary GAM: by directly Newton-optimising the loss
+    with **P-IRLS** (penalised iteratively reweighted least squares) for the
+    basis coefficients, wrapped in an **outer** loop that re-selects each
+    view's smoothing parameter by (efficient, leave-one-out) cross-validation
+    — the same statistical job ``mgcv``'s GCV/REML step does — and
+    alternating the two until both the coefficients and the smoothing
+    parameters stop changing:
+
+    1. **Inner (P-IRLS)**: for the *current, fixed* smoothing parameters,
+       repeatedly form a Newton step on $\mathcal{L}_{EY}$ for each view in
+       turn — a working response $Z_i - \nabla_i / h_i$ (from the analytic
+       gradient :func:`~cca_zoo._utils._ey.ey_grad_z` and a diagonal-Hessian
+       weight, see :func:`_diag_hessian`) ridge-fit onto that view's fixed
+       B-spline basis — cycling through every view until the EY loss itself
+       stops moving.
+    2. **Outer (GCV-style)**: only once the inner loop has converged, re-fit
+       each view's smoothing parameter with :class:`~sklearn.linear_model.RidgeCV`
+       at that converged state, then re-run the inner loop at the new
+       parameters. Repeat until the smoothing parameters stabilise too.
+
+    This is a genuine departure from the boosting-based recipe
+    :class:`~cca_zoo.tree.TreeCCA` uses (necessary there because a
+    tree ensemble has no closed-form single-shot fit to a moving target):
+    GAMCCA never takes a small shrunk step, and has no `learning_rate` or
+    `n_estimators` to tune — each view's smoothing strength is chosen
+    automatically, the same way it would be for any other GAM. Everything
+    here is built from scikit-learn's own, already-required machinery
+    (``SplineTransformer``, ``Ridge``, ``RidgeCV``); no optional dependency
+    or custom Newton/GCV solver is needed.
 
     Note:
-        A GAM's additive structure assumes each feature contributes
+        The Hessian used above is a *diagonal* (per-sample) approximation
+        of the true, dense Hessian (which has a rank-1 correction beyond
+        diagonal — every sample's curvature is coupled to every other's
+        through $\operatorname{Var}(Z_i)$). That approximation needs its own
+        damping: near the loss's own well-conditioned fixed point
+        ($V \approx 1$), the diagonal collapses to a per-sample value with
+        an enormous, sign-changing dynamic range, so it is floored at a high
+        percentile of its own distribution (self-calibrating, rather than a
+        fixed constant that would need re-tuning per dataset) — this acts
+        like Levenberg-Marquardt damping, treating typical samples with an
+        approximately uniform weight and only letting the Hessian's signal
+        through for high-leverage outliers. The same diagonal Hessian does
+        *not* carry over usefully to :class:`~cca_zoo.tree.TreeCCA`'s
+        boosting: tree splits aggregate `grad`/`hess` sums *within each
+        leaf* as if independent, which requires the Hessian to genuinely be
+        (close to) diagonal — true for an ordinary GLM's per-observation
+        likelihood, false here, where the curvature is fundamentally a
+        global, rank-1 object. A ridge fit instead solves one global,
+        basis-regularised system, so it isn't sensitive to the same mismatch.
+
+        A GAM's additive structure also assumes each feature contributes
         independently; it cannot represent a genuine *interaction* between
         two features of the same view (e.g. $x_1 x_2$) the way a
         multivariate tree split can. If cross-view structure only shows up
@@ -159,12 +326,11 @@ class GAMCCA(BaseModel):
         do better instead.
 
     References:
+        Wood, S. N. (2017). Generalized Additive Models: An Introduction
+        with R (2nd ed.). Chapman and Hall/CRC.
+
         Eilers, P. H., & Marx, B. D. (1996). Flexible smoothing with
         B-splines and penalties. Statistical Science, 11(2), 89-121.
-
-        Bühlmann, P., & Yu, B. (2003). Boosting with the L2 loss:
-        regression and classification. Journal of the American Statistical
-        Association, 98(462), 324-339.
 
         Chapman, J., Wells, L., & Lawry Aguila, A. (2024). Unconstrained
         Stochastic CCA: Unifying Multiview and Self-Supervised Learning.
@@ -175,21 +341,21 @@ class GAMCCA(BaseModel):
             number of features in any view. Default is 1.
         center: Whether to subtract per-view column means before fitting.
             Default is True.
-        n_estimators: Number of boosting rounds. Default is 150.
         n_knots: Number of knots per feature's B-spline term, passed
             straight through to ``sklearn.preprocessing.SplineTransformer(
             n_knots=...)``. Default is 5.
-        learning_rate: Boosting shrinkage applied to each round's ridge fit.
-            Default is 0.3.
-        ridge: Ridge penalty for each round's per-view spline fit, passed
-            straight through to ``sklearn.linear_model.Ridge(alpha=...)``.
-            Higher values give smoother, less wiggly per-feature curves at
-            the cost of slower convergence, and are the main defence
-            against overfitting a single view's noise. Default is 0.1.
-        gauss_seidel: If True, re-predict view 1's embedding after updating
-            its encoder and use the fresh values when computing view 2's
-            gradient (Gauss-Seidel); if False, both gradients are computed
-            from the same stale embeddings (Jacobi). Default is True.
+        alphas: Candidate smoothing parameters searched by
+            :class:`~sklearn.linear_model.RidgeCV` in the outer loop.
+            Default (``None``) uses ``numpy.logspace(-6, 3, 10)``.
+        max_inner_iter: Maximum P-IRLS rounds (cycling once through every
+            view per round) per outer iteration. Default is 50.
+        max_outer_iter: Maximum smoothing-parameter re-selection rounds.
+            Default is 10.
+        tol: Inner-loop convergence tolerance, on the change in the EY loss
+            between successive full passes over all views. Default is 1e-4.
+        hess_floor_percentile: Percentile (0-100) of each round's raw
+            diagonal-Hessian values used to floor them (see
+            :func:`_diag_hessian`). Default is 90.0.
         random_state: Seed for drawing the random-orthogonal initial
             embedding. Default is 0.
 
@@ -198,36 +364,38 @@ class GAMCCA(BaseModel):
         >>> rng = np.random.default_rng(0)
         >>> X1 = rng.standard_normal((200, 5))
         >>> X2 = rng.standard_normal((200, 5))
-        >>> model = GAMCCA(latent_dimensions=2, n_estimators=20).fit([X1, X2])
+        >>> model = GAMCCA(latent_dimensions=2).fit([X1, X2])
         >>> scores = model.transform([X1, X2])
     """
 
     _parameter_constraints: ClassVar[dict[str, list[Any]]] = {
         **BaseModel._parameter_constraints,
-        "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "n_knots": [Interval(Integral, 2, None, closed="left")],
-        "learning_rate": [Interval(Real, 0, None, closed="neither")],
-        "ridge": [Interval(Real, 0, None, closed="left")],
-        "gauss_seidel": ["boolean"],
+        "max_inner_iter": [Interval(Integral, 1, None, closed="left")],
+        "max_outer_iter": [Interval(Integral, 1, None, closed="left")],
+        "tol": [Interval(Real, 0, None, closed="neither")],
+        "hess_floor_percentile": [Interval(Real, 0, 100, closed="both")],
     }
 
     def __init__(
         self,
         latent_dimensions: int = 1,
         center: bool = True,
-        n_estimators: int = 150,
         n_knots: int = 5,
-        learning_rate: float = 0.3,
-        ridge: float = 0.1,
-        gauss_seidel: bool = True,
+        alphas: ArrayLike | None = None,
+        max_inner_iter: int = 50,
+        max_outer_iter: int = 10,
+        tol: float = 1e-4,
+        hess_floor_percentile: float = 90.0,
         random_state: int = 0,
     ) -> None:
         super().__init__(latent_dimensions=latent_dimensions, center=center)
-        self.n_estimators = n_estimators
         self.n_knots = n_knots
-        self.learning_rate = learning_rate
-        self.ridge = ridge
-        self.gauss_seidel = gauss_seidel
+        self.alphas = alphas
+        self.max_inner_iter = max_inner_iter
+        self.max_outer_iter = max_outer_iter
+        self.tol = tol
+        self.hess_floor_percentile = hess_floor_percentile
         self.random_state = random_state
 
     def fit(self, views: list[ArrayLike], y: None = None) -> GAMCCA:
@@ -247,31 +415,70 @@ class GAMCCA(BaseModel):
         views_ = self._setup_fit(views)
         k = self.latent_dimensions
         n_views = len(views_)
+        n = views_[0].shape[0]
+        n_minus_1 = n - 1
+        alpha_grid = (
+            np.asarray(self.alphas)
+            if self.alphas is not None
+            else np.logspace(-6, 3, 10)
+        )
 
         rng = np.random.default_rng(self.random_state)
-        base_margins = []
-        projections = []
+        encoders = [_GamEncoder(X, k, self.n_knots) for X in views_]
+        representations = []
         for X in views_:
-            bm, proj = random_orthogonal_embedding(X, k, rng)
-            base_margins.append(bm)
-            projections.append(proj)
-        self._projections_: list[np.ndarray] = projections
+            bm, _ = random_orthogonal_embedding(X, k, rng)
+            representations.append(bm)
 
-        encoders = [_GamEncoder(X, k, self.n_knots, self.ridge) for X in views_]
+        prev_alphas = [enc.alphas_.copy() for enc in encoders]
+        for outer_it in range(self.max_outer_iter):
+            # Outer loop: re-select each view's smoothing parameter via
+            # RidgeCV's efficient LOOCV, at the current representations.
+            for i in range(n_views):
+                grad = ey_grad_z(representations)[i]
+                _, V = ey_cross_covariance(representations)
+                diag_hess = _diag_hessian(
+                    representations[i],
+                    V,
+                    n_views,
+                    n_minus_1,
+                    self.hess_floor_percentile,
+                )
+                encoders[i].outer_step(representations[i], grad, diag_hess, alpha_grid)
+                representations[i] = encoders[i].predict()
 
-        for _ in range(self.n_estimators):
-            representations = [
-                bm + enc.predict() for bm, enc in zip(base_margins, encoders)
-            ]
-            grads = rescale_grads_to_target_std(ey_grad_z(representations))
-
-            for view_idx in range(n_views):
-                encoders[view_idx].boost(grads[view_idx], self.learning_rate)
-                if self.gauss_seidel and view_idx < n_views - 1:
-                    representations[view_idx] = (
-                        base_margins[view_idx] + encoders[view_idx].predict()
+            # Inner loop: P-IRLS Newton steps at these now-fixed smoothing
+            # parameters, cycling through every view, until the EY loss
+            # itself stops moving (see _diag_hessian's docstring for why
+            # this, rather than raw per-sample values, is the right
+            # convergence signal to track).
+            prev_obj = ey_loss(representations)["objective"]
+            for _ in range(self.max_inner_iter):
+                for i in range(n_views):
+                    grad = ey_grad_z(representations)[i]
+                    _, V = ey_cross_covariance(representations)
+                    diag_hess = _diag_hessian(
+                        representations[i],
+                        V,
+                        n_views,
+                        n_minus_1,
+                        self.hess_floor_percentile,
                     )
-                    grads = rescale_grads_to_target_std(ey_grad_z(representations))
+                    encoders[i].inner_step(representations[i], grad, diag_hess)
+                    representations[i] = encoders[i].predict()
+                obj = ey_loss(representations)["objective"]
+                if abs(obj - prev_obj) < self.tol:
+                    break
+                prev_obj = obj
+
+            alphas_now = [enc.alphas_.copy() for enc in encoders]
+            alpha_change = max(
+                np.max(np.abs(np.log(now) - np.log(prev)))
+                for now, prev in zip(alphas_now, prev_alphas)
+            )
+            prev_alphas = alphas_now
+            if outer_it > 0 and alpha_change < 0.05:
+                break
 
         self.encoders_: list[_GamEncoder] = encoders
         return self
@@ -293,11 +500,7 @@ class GAMCCA(BaseModel):
         check_is_fitted(self)
         validated = validate_views(views)
         centred = [v - m for v, m in zip(validated, self.means_)]
-        result = []
-        for v, enc, projection in zip(centred, self.encoders_, self._projections_):
-            bm = v @ projection
-            result.append(bm + enc.predict_new(v))
-        return result
+        return [enc.predict_new(v) for v, enc in zip(centred, self.encoders_)]
 
     def shape_function(self, view: int, feature: int, x: ArrayLike) -> np.ndarray:
         r"""Evaluate one feature's fitted additive term $s_j(x_j)$.

--- a/cca_zoo/gp/__init__.py
+++ b/cca_zoo/gp/__init__.py
@@ -1,0 +1,7 @@
+"""Gaussian-process (GP) nonlinear CCA methods."""
+
+from __future__ import annotations
+
+from cca_zoo.gp._gpcca import GPCCA
+
+__all__ = ["GPCCA"]

--- a/cca_zoo/gp/_gpcca.py
+++ b/cca_zoo/gp/_gpcca.py
@@ -1,0 +1,426 @@
+"""GPCCA — Gaussian-process Canonical Correlation Analysis."""
+
+from __future__ import annotations
+
+from numbers import Integral, Real
+from typing import Any, ClassVar
+
+import numpy as np
+from numpy.typing import ArrayLike
+from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process.kernels import RBF, ConstantKernel
+from sklearn.utils._param_validation import Interval
+from sklearn.utils.validation import check_is_fitted
+
+from cca_zoo._base import BaseModel
+from cca_zoo._utils._ey import (
+    ey_cross_covariance,
+    ey_diag_hessian,
+    ey_grad_z,
+    ey_loss,
+    random_orthogonal_embedding,
+)
+from cca_zoo._utils._validation import validate_views
+
+
+class _GpEncoder:
+    r"""Per-view joint-kernel GP encoder, fit by inner/outer Newton + ML-II steps.
+
+    Where :class:`~cca_zoo.gam._gamcca._GamEncoder` sums one univariate
+    B-spline term per feature (additive, so it cannot see cross-feature
+    interactions), this encoder fits one
+    :class:`~sklearn.gaussian_process.GaussianProcessRegressor` per latent
+    component directly on the raw (joint) feature vector, using an ARD
+    (per-dimension-lengthscale) RBF kernel — a genuine, non-additive
+    function of all of that view's features at once. The two step kinds
+    mirror ``_GamEncoder``'s inner/outer split exactly, with the GP's own
+    machinery standing in for ``Ridge``/``RidgeCV``:
+
+    - :meth:`inner_step` — one Newton step on the EY loss (a working
+      response $Z_i - \nabla_i / h_i$, from
+      :func:`~cca_zoo._utils._ey.ey_grad_z` and
+      :func:`~cca_zoo._utils._ey.ey_diag_hessian`) fit with the kernel's
+      hyperparameters held fixed at their current value
+      (``optimizer=None``), passing the diagonal-Hessian weights as the
+      GP's per-sample ``alpha`` (heteroscedastic observation noise).
+    - :meth:`outer_step` — re-fits the same working response with the
+      kernel hyperparameters (lengthscales, signal variance) free to move,
+      via the GP's own default marginal-likelihood optimisation — the
+      direct GP analogue of GCV/REML smoothing-parameter search.
+
+    Used only during ``fit``.
+    """
+
+    def __init__(self, X: np.ndarray, k: int) -> None:
+        self.n, self.p = X.shape
+        self.k = k
+        self.X = X
+        self.kernels_: list[Any] = [
+            ConstantKernel(1.0) * RBF(length_scale=np.ones(self.p)) for _ in range(k)
+        ]
+        self.models_: list[GaussianProcessRegressor] = []
+        self.whiten_: np.ndarray = np.eye(k)
+        self.raw_mean_: np.ndarray = np.zeros(k)
+        self._train_pred: np.ndarray = np.zeros((self.n, k))
+
+    def predict(self) -> np.ndarray:
+        """Encoder output on the training data, shape (n_samples, k)."""
+        return self._train_pred
+
+    def _update_from_raw(self, raw: np.ndarray) -> None:
+        """Whiten a raw (pre-decorrelation) prediction and cache it.
+
+        See :meth:`cca_zoo.gam._gamcca._GamEncoder._update_from_raw` for why
+        this re-centring, and caching ``raw_mean_`` for reuse by
+        :meth:`predict_new`, is necessary.
+        """
+        self.raw_mean_ = raw.mean(axis=0)
+        centred = raw - self.raw_mean_
+        cov = (centred.T @ centred) / (centred.shape[0] - 1)
+        vals, vecs = np.linalg.eigh(cov)
+        vals = np.maximum(vals, 1e-8)
+        self.whiten_ = vecs @ np.diag(vals**-0.5) @ vecs.T
+        self._train_pred = centred @ self.whiten_
+
+    def _working_response_and_alpha(
+        self, Z_self: np.ndarray, grad: np.ndarray, diag_hess: np.ndarray, c: int
+    ) -> tuple[np.ndarray, np.ndarray]:
+        working_response = Z_self[:, c] - grad[:, c] / diag_hess[:, c]
+        alpha = np.clip(1.0 / diag_hess[:, c], 1e-6, 1e6)
+        return working_response, alpha
+
+    def inner_step(
+        self, Z_self: np.ndarray, grad: np.ndarray, diag_hess: np.ndarray
+    ) -> None:
+        """One Newton update with the kernel hyperparameters held fixed.
+
+        Args:
+            Z_self: This view's current embedding, shape (n_samples, k).
+            grad: EY-loss gradient for this view (see
+                :func:`~cca_zoo._utils._ey.ey_grad_z`), shape (n_samples, k).
+            diag_hess: Diagonal-Hessian weights (see
+                :func:`~cca_zoo._utils._ey.ey_diag_hessian`), shape (n_samples, k).
+        """
+        raw_cols = []
+        models = []
+        for c in range(self.k):
+            working_response, alpha = self._working_response_and_alpha(
+                Z_self, grad, diag_hess, c
+            )
+            model = GaussianProcessRegressor(
+                kernel=self.kernels_[c], alpha=alpha, optimizer=None
+            )
+            model.fit(self.X, working_response)
+            models.append(model)
+            raw_cols.append(model.predict(self.X))
+        self.models_ = models
+        self._update_from_raw(np.column_stack(raw_cols))
+
+    def outer_step(
+        self, Z_self: np.ndarray, grad: np.ndarray, diag_hess: np.ndarray
+    ) -> None:
+        """Re-fit the kernel hyperparameters via marginal-likelihood search.
+
+        Args:
+            Z_self: This view's current embedding, shape (n_samples, k).
+            grad: EY-loss gradient for this view, shape (n_samples, k).
+            diag_hess: Diagonal-Hessian weights, shape (n_samples, k).
+        """
+        raw_cols = []
+        models = []
+        for c in range(self.k):
+            working_response, alpha = self._working_response_and_alpha(
+                Z_self, grad, diag_hess, c
+            )
+            model = GaussianProcessRegressor(kernel=self.kernels_[c], alpha=alpha)
+            model.fit(self.X, working_response)
+            models.append(model)
+            self.kernels_[c] = model.kernel_
+            raw_cols.append(model.predict(self.X))
+        self.models_ = models
+        self._update_from_raw(np.column_stack(raw_cols))
+
+    def predict_new(
+        self, X: np.ndarray, return_std: bool = False
+    ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+        """Encoder output for arbitrary (e.g. test) data, shape (n, k).
+
+        Args:
+            X: Input data, shape (n_samples, n_features).
+            return_std: If True, also return the posterior standard
+                deviation of each latent component, propagated through the
+                (linear) whitening transform.
+
+        Returns:
+            Array of shape (n, k), or, if ``return_std`` is True, a tuple
+            ``(mean, std)`` of two arrays each of shape (n, k).
+        """
+        if return_std:
+            raw_mean = np.empty((X.shape[0], self.k))
+            raw_std = np.empty((X.shape[0], self.k))
+            for c, m in enumerate(self.models_):
+                raw_mean[:, c], raw_std[:, c] = m.predict(X, return_std=True)
+            mean = (raw_mean - self.raw_mean_) @ self.whiten_
+            # Each component's raw GP posterior is fit independently, so
+            # the raw covariance is diagonal; propagating variances through
+            # the whitening transform is then a plain matrix product of
+            # variances against squared whitening weights (no cross terms).
+            var = raw_std**2 @ (self.whiten_**2)
+            return mean, np.sqrt(var)
+        raw = np.column_stack([m.predict(X) for m in self.models_])
+        result: np.ndarray = (raw - self.raw_mean_) @ self.whiten_
+        return result
+
+
+class GPCCA(BaseModel):
+    r"""GPCCA — nonlinear multiview CCA with Gaussian-process encoders.
+
+    Learns one nonlinear encoder $f_i$ per view — a Gaussian process with
+    an ARD (per-feature-lengthscale) RBF kernel over that view's *raw,
+    joint* feature vector — that jointly maximise the Eckart-Young (EY)
+    unconstrained-CCA objective:
+
+    $$
+    \mathcal{L}_{EY} = -2 \operatorname{tr}(C) + \operatorname{tr}(V V)
+    $$
+
+    where, for embeddings $Z_i = f_i(X_i)$, $C$ is the mean pairwise
+    cross-covariance (including $i = j$ terms) and $V$ the mean
+    auto-covariance across all views (see :mod:`cca_zoo._utils._ey`, the
+    same shared EY-loss machinery used by
+    :class:`~cca_zoo.linear.gradient.CCA_EY`, :class:`~cca_zoo.deep.DCCA_EY`,
+    :class:`~cca_zoo.tree.TreeCCA`, and :class:`~cca_zoo.gam.GAMCCA`).
+
+    Unlike :class:`~cca_zoo.gam.GAMCCA`'s per-feature additive splines, a
+    GP with a joint kernel is not restricted to a sum of univariate terms:
+    it can represent a genuine *interaction* between two features of the
+    same view (e.g. cross-view structure that only shows up through
+    $x_1 x_2$, not through $x_1$ or $x_2$ alone) directly and efficiently,
+    the way a decision tree's multivariate splits can but an additive GAM
+    structurally cannot. As a Bayesian model it also comes with calibrated
+    predictive uncertainty for free: :meth:`transform` can return each
+    latent component's posterior standard deviation alongside its mean.
+
+    Fitting follows the same inner/outer split as
+    :class:`~cca_zoo.gam.GAMCCA`'s P-IRLS/GCV recipe, with the GP's own
+    machinery in place of ``Ridge``/``RidgeCV``:
+
+    1. **Inner (fixed-kernel Newton steps)**: for the *current* kernel
+       hyperparameters, repeatedly form a Newton step on
+       $\mathcal{L}_{EY}$ for each view in turn — a working response
+       $Z_i - \nabla_i / h_i$ (from the analytic gradient
+       :func:`~cca_zoo._utils._ey.ey_grad_z` and a diagonal-Hessian weight,
+       see :func:`~cca_zoo._utils._ey.ey_diag_hessian`) fit with
+       :class:`~sklearn.gaussian_process.GaussianProcessRegressor`
+       (``optimizer=None``, so the kernel is held fixed), passing the
+       diagonal-Hessian weights as the GP's per-sample ``alpha``
+       (heteroscedastic observation noise) — cycling through every view
+       until the EY loss itself stops moving.
+    2. **Outer (marginal-likelihood kernel search)**: only once the inner
+       loop has converged, re-fit each view's kernel hyperparameters at
+       that converged working response via the GP's own default
+       log-marginal-likelihood optimisation (the same statistical role
+       GCV/REML plays for GAMCCA), then re-run the inner loop at the new
+       kernel. Repeat until the kernel hyperparameters stabilise too.
+
+    Everything here is built from scikit-learn's own, already-required
+    ``GaussianProcessRegressor``/``RBF``/``ConstantKernel``; no optional
+    dependency or custom solver is needed.
+
+    Note:
+        As with :class:`~cca_zoo.gam.GAMCCA`, the diagonal-Hessian weight
+        is only a per-sample approximation of the loss's true (dense,
+        rank-1-coupled) Hessian — see
+        :func:`~cca_zoo._utils._ey.ey_diag_hessian`'s docstring for the
+        full derivation and why it needs floor-damping. It is used here in
+        exactly the role a GP's heteroscedastic ``alpha`` already exists
+        to play (how much to trust each observation), so no further
+        adaptation is needed beyond what :class:`~cca_zoo.gam.GAMCCA`
+        already requires.
+
+        A GP over the raw feature vector scales cubically in the number of
+        training samples (exact GP inference); for very large datasets
+        expect fitting to be markedly slower than
+        :class:`~cca_zoo.gam.GAMCCA` or :class:`~cca_zoo.tree.TreeCCA`.
+
+    References:
+        Rasmussen, C. E., & Williams, C. K. I. (2006). Gaussian Processes
+        for Machine Learning. MIT Press.
+
+        Chapman, J., Wells, L., & Lawry Aguila, A. (2024). Unconstrained
+        Stochastic CCA: Unifying Multiview and Self-Supervised Learning.
+        arXiv:2310.01012.
+
+    Args:
+        latent_dimensions: Number of latent components. Must not exceed the
+            number of features in any view. Default is 1.
+        center: Whether to subtract per-view column means before fitting.
+            Default is True.
+        max_inner_iter: Maximum fixed-kernel Newton rounds (cycling once
+            through every view per round) per outer iteration. Default is 15.
+        max_outer_iter: Maximum kernel-hyperparameter re-selection rounds.
+            Default is 4.
+        tol: Inner-loop convergence tolerance, on the change in the EY loss
+            between successive full passes over all views. Default is 1e-3.
+        hess_floor_percentile: Percentile (0-100) of each round's raw
+            diagonal-Hessian values used to floor them (see
+            :func:`~cca_zoo._utils._ey.ey_diag_hessian`). Default is 90.0.
+        random_state: Seed for drawing the random-orthogonal initial
+            embedding. Default is 0.
+
+    Example:
+        >>> import numpy as np
+        >>> rng = np.random.default_rng(0)
+        >>> X1 = rng.standard_normal((100, 3))
+        >>> X2 = rng.standard_normal((100, 3))
+        >>> model = GPCCA(latent_dimensions=1).fit([X1, X2])
+        >>> scores = model.transform([X1, X2])
+        >>> means, stds = model.transform([X1, X2], return_std=True)
+    """
+
+    _parameter_constraints: ClassVar[dict[str, list[Any]]] = {
+        **BaseModel._parameter_constraints,
+        "max_inner_iter": [Interval(Integral, 1, None, closed="left")],
+        "max_outer_iter": [Interval(Integral, 1, None, closed="left")],
+        "tol": [Interval(Real, 0, None, closed="neither")],
+        "hess_floor_percentile": [Interval(Real, 0, 100, closed="both")],
+    }
+
+    def __init__(
+        self,
+        latent_dimensions: int = 1,
+        center: bool = True,
+        max_inner_iter: int = 15,
+        max_outer_iter: int = 4,
+        tol: float = 1e-3,
+        hess_floor_percentile: float = 90.0,
+        random_state: int = 0,
+    ) -> None:
+        super().__init__(latent_dimensions=latent_dimensions, center=center)
+        self.max_inner_iter = max_inner_iter
+        self.max_outer_iter = max_outer_iter
+        self.tol = tol
+        self.hess_floor_percentile = hess_floor_percentile
+        self.random_state = random_state
+
+    def fit(self, views: list[ArrayLike], y: None = None) -> GPCCA:
+        """Fit the GPCCA model.
+
+        Args:
+            views: List of 2 or more arrays, each (n_samples, n_features_i).
+            y: Ignored.
+
+        Returns:
+            self: Fitted estimator.
+
+        Raises:
+            ValueError: If fewer than 2 views are provided.
+            ValueError: If views have inconsistent numbers of samples.
+        """
+        views_ = self._setup_fit(views)
+        k = self.latent_dimensions
+        n_views = len(views_)
+        n = views_[0].shape[0]
+        n_minus_1 = n - 1
+
+        rng = np.random.default_rng(self.random_state)
+        encoders = [_GpEncoder(X, k) for X in views_]
+        representations = []
+        for X in views_:
+            bm, _ = random_orthogonal_embedding(X, k, rng)
+            representations.append(bm)
+
+        for outer_it in range(self.max_outer_iter):
+            # Outer loop: re-select each view's kernel hyperparameters via
+            # marginal-likelihood optimisation, at the current representations.
+            for i in range(n_views):
+                grad = ey_grad_z(representations)[i]
+                _, V = ey_cross_covariance(representations)
+                diag_hess = ey_diag_hessian(
+                    representations[i],
+                    V,
+                    n_views,
+                    n_minus_1,
+                    self.hess_floor_percentile,
+                )
+                encoders[i].outer_step(representations[i], grad, diag_hess)
+                representations[i] = encoders[i].predict()
+
+            # Inner loop: fixed-kernel Newton steps, cycling through every
+            # view, until the EY loss itself stops moving (see
+            # ey_diag_hessian's docstring for why this, rather than raw
+            # per-sample values, is the right convergence signal to track).
+            prev_obj = ey_loss(representations)["objective"]
+            for _ in range(self.max_inner_iter):
+                for i in range(n_views):
+                    grad = ey_grad_z(representations)[i]
+                    _, V = ey_cross_covariance(representations)
+                    diag_hess = ey_diag_hessian(
+                        representations[i],
+                        V,
+                        n_views,
+                        n_minus_1,
+                        self.hess_floor_percentile,
+                    )
+                    encoders[i].inner_step(representations[i], grad, diag_hess)
+                    representations[i] = encoders[i].predict()
+                obj = ey_loss(representations)["objective"]
+                if abs(obj - prev_obj) < self.tol:
+                    break
+                prev_obj = obj
+
+        self.encoders_: list[_GpEncoder] = encoders
+        return self
+
+    def transform(  # type: ignore[override]
+        self, views: list[ArrayLike], return_std: bool = False
+    ) -> list[np.ndarray] | tuple[list[np.ndarray], list[np.ndarray]]:
+        """Project views into the latent space using the fitted encoders.
+
+        Args:
+            views: List of arrays, each (n_samples, n_features_i), matching
+                the number of views passed to ``fit``.
+            return_std: If True, also return each view's posterior standard
+                deviation, propagated through the whitening transform.
+
+        Returns:
+            List of arrays, each (n_samples, latent_dimensions); or, if
+            ``return_std`` is True, a tuple ``(means, stds)`` of two such
+            lists.
+
+        Raises:
+            sklearn.exceptions.NotFittedError: If ``fit`` has not been called.
+            ValueError: If fewer than 2 views are provided.
+        """
+        check_is_fitted(self)
+        validated = validate_views(views)
+        centred = [v - m for v, m in zip(validated, self.means_)]
+        if return_std:
+            means = []
+            stds = []
+            for v, enc in zip(centred, self.encoders_):
+                mean, std = enc.predict_new(v, return_std=True)
+                means.append(mean)
+                stds.append(std)
+            return means, stds
+        return [enc.predict_new(v) for v, enc in zip(centred, self.encoders_)]
+
+    @property
+    def weights(self) -> list[np.ndarray]:
+        """Not implemented for GPCCA.
+
+        Raises:
+            sklearn.exceptions.NotFittedError: If ``fit`` has not been called.
+            NotImplementedError: GPCCA encoders are Gaussian processes over
+                the joint feature vector, not linear weight matrices, and
+                have no per-feature decomposition analogous to
+                :meth:`~cca_zoo.gam.GAMCCA.shape_function` (the kernel is
+                not additive across features).
+        """
+        check_is_fitted(self)
+        raise NotImplementedError(
+            "GPCCA has no linear weight matrices; its encoders are "
+            "Gaussian processes with a joint (non-additive) kernel over "
+            "each view's raw features, so there is no per-feature "
+            "decomposition to expose."
+        )

--- a/cca_zoo/gp/_gpcca.py
+++ b/cca_zoo/gp/_gpcca.py
@@ -7,6 +7,8 @@ from typing import Any, ClassVar
 
 import numpy as np
 from numpy.typing import ArrayLike
+from scipy.linalg import cho_solve, cholesky, solve_triangular
+from sklearn.cluster import kmeans_plusplus
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import RBF, ConstantKernel
 from sklearn.utils._param_validation import Interval
@@ -172,6 +174,188 @@ class _GpEncoder:
         return result
 
 
+_JITTER = 1e-6
+
+
+class _SparseGpEncoder(_GpEncoder):
+    r"""Sparse (inducing-point) variant of :class:`_GpEncoder`, for $n \gg m$.
+
+    Exact GP inference costs $O(n^3)$ per Newton step (a full Cholesky of
+    an $(n, n)$ matrix, repeated at every :meth:`inner_step` and
+    :meth:`outer_step` call) — prohibitive once ``n_samples`` reaches a few
+    thousand. This encoder instead uses the **Deterministic Training
+    Conditional (DTC)** / projected-process sparse approximation (Csató &
+    Opper, 2002; Seeger et al., 2003; unified with FITC and other sparse
+    methods by Quiñonero-Candela & Rasmussen, 2005, "A Unifying View of
+    Sparse Approximate Gaussian Process Regression", JMLR 6:1939-1959):
+    the GP is conditioned on $m \ll n$ **inducing points** $Z$ (chosen as
+    an actual, well-spread subset of the $n$ training rows, via
+    :func:`sklearn.cluster.kmeans_plusplus`'s seeding — the same
+    initialisation scheme :class:`~sklearn.cluster.KMeans` uses to spread
+    its starting centroids over the data), and every posterior formula is
+    then a function of the $(n, m)$ and $(m, m)$ cross/inducing covariance
+    matrices instead of the full $(n, n)$ one:
+
+    $$
+    Q_{mm} = K_{mm} + K_{mn} \Lambda^{-1} K_{nm}, \qquad
+    \text{mean}(x_*) = k_{*m} Q_{mm}^{-1} K_{mn} \Lambda^{-1} y
+    $$
+
+    $$
+    \operatorname{var}(x_*) = k_{**} - k_{*m} K_{mm}^{-1} k_{m*}
+        + k_{*m} Q_{mm}^{-1} k_{m*}
+    $$
+
+    where $\Lambda = \operatorname{diag}(\alpha)$ is the (heteroscedastic)
+    per-sample noise variance — here the same diagonal-Hessian weight used
+    throughout GPCCA. This costs $O(n m^2 + m^3)$: linear rather than
+    cubic in $n$, at the price of an approximation whose quality depends
+    on how well $m$ inducing points span the data.
+
+    The inner/outer split carries over directly, with the *hyperparameter
+    search* delegated to a cheap exact GP fit on the $m$ inducing rows
+    alone (the marginal-likelihood optimisation itself is what would be
+    expensive at full scale; on $m$ points it costs $O(m^3)$), while the
+    actual *predictions* used to build each round's representation are
+    always computed from the DTC formula over all $n$ training rows — so
+    only the hyperparameter search, not the fit itself, is approximated
+    from a subsample:
+
+    - :meth:`inner_step` — holds the kernel (and therefore $K_{mm}$,
+      $K_{nm}$) fixed, and only recomputes $Q_{mm}$ and the posterior mean
+      from the current working response.
+    - :meth:`outer_step` — refits kernel hyperparameters on the $m$
+      inducing rows via :class:`~sklearn.gaussian_process.GaussianProcessRegressor`'s
+      default marginal-likelihood optimiser, refreshes the cached
+      $K_{mm}$/$K_{nm}$ for the new kernel, then computes the DTC
+      posterior mean over all $n$ rows at that kernel.
+
+    Used only during ``fit``.
+    """
+
+    def __init__(
+        self, X: np.ndarray, k: int, n_inducing: int, random_state: int
+    ) -> None:
+        super().__init__(X, k)
+        self.n_inducing = n_inducing
+        _, inducing_idx = kmeans_plusplus(
+            X, n_clusters=n_inducing, random_state=random_state
+        )
+        self.inducing_idx_ = inducing_idx
+        self.Z_ = X[inducing_idx]
+        self._Kmm: list[np.ndarray] = [np.empty((0, 0))] * k
+        self._Lmm: list[np.ndarray] = [np.empty((0, 0))] * k
+        self._Knm: list[np.ndarray] = [np.empty((0, 0))] * k
+        self._Lq: list[np.ndarray] = [np.empty((0, 0))] * k
+        self._coef: list[np.ndarray] = [np.zeros(n_inducing)] * k
+
+    def _refresh_kernel_cache(self, c: int) -> None:
+        """Recompute $K_{mm}$/$K_{nm}$ (and $K_{mm}$'s Cholesky) for component ``c``.
+
+        Only needed when component ``c``'s kernel hyperparameters change
+        (i.e. from :meth:`outer_step`) — both matrices depend on the
+        kernel and inducing/training locations alone, not on the working
+        response or its noise weights, so :meth:`inner_step` reuses them
+        unchanged across every Newton iteration at a fixed kernel.
+        """
+        kernel = self.kernels_[c]
+        Kmm = kernel(self.Z_) + _JITTER * np.eye(self.n_inducing)
+        self._Kmm[c] = Kmm
+        self._Lmm[c] = cholesky(Kmm, lower=True)
+        self._Knm[c] = kernel(self.X, self.Z_)
+
+    def _dtc_mean(
+        self, c: int, working_response: np.ndarray, alpha: np.ndarray
+    ) -> np.ndarray:
+        """DTC posterior mean on the training rows; caches $Q_{mm}$'s solve.
+
+        Args:
+            c: Component index.
+            working_response: This component's working response, shape (n,).
+            alpha: This component's per-sample noise variance, shape (n,).
+
+        Returns:
+            Posterior mean on the training rows, shape (n,).
+        """
+        Knm = self._Knm[c]
+        Kmn_scaled = Knm.T / alpha[None, :]
+        Qmm = self._Kmm[c] + Kmn_scaled @ Knm + _JITTER * np.eye(self.n_inducing)
+        Lq = cholesky(Qmm, lower=True)
+        b = Kmn_scaled @ working_response
+        coef = cho_solve((Lq, True), b)
+        self._Lq[c] = Lq
+        self._coef[c] = coef
+        result: np.ndarray = Knm @ coef
+        return result
+
+    def inner_step(
+        self, Z_self: np.ndarray, grad: np.ndarray, diag_hess: np.ndarray
+    ) -> None:
+        """One DTC Newton update with the kernel hyperparameters held fixed.
+
+        Args: as :meth:`_GpEncoder.inner_step`.
+        """
+        raw_cols = []
+        for c in range(self.k):
+            working_response, alpha = self._working_response_and_alpha(
+                Z_self, grad, diag_hess, c
+            )
+            raw_cols.append(self._dtc_mean(c, working_response, alpha))
+        self._update_from_raw(np.column_stack(raw_cols))
+
+    def outer_step(
+        self, Z_self: np.ndarray, grad: np.ndarray, diag_hess: np.ndarray
+    ) -> None:
+        """Re-fit kernel hyperparameters on the inducing rows, via exact GP.
+
+        Args: as :meth:`_GpEncoder.outer_step`.
+        """
+        models = []
+        raw_cols = []
+        idx = self.inducing_idx_
+        for c in range(self.k):
+            working_response, alpha = self._working_response_and_alpha(
+                Z_self, grad, diag_hess, c
+            )
+            model = GaussianProcessRegressor(kernel=self.kernels_[c], alpha=alpha[idx])
+            model.fit(self.Z_, working_response[idx])
+            models.append(model)
+            self.kernels_[c] = model.kernel_
+            self._refresh_kernel_cache(c)
+            raw_cols.append(self._dtc_mean(c, working_response, alpha))
+        self.models_ = models
+        self._update_from_raw(np.column_stack(raw_cols))
+
+    def predict_new(
+        self, X: np.ndarray, return_std: bool = False
+    ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+        """Encoder output for arbitrary (e.g. test) data, via the DTC formula.
+
+        Args: as :meth:`_GpEncoder.predict_new`.
+        """
+        n_new = X.shape[0]
+        raw_mean = np.empty((n_new, self.k))
+        if return_std:
+            raw_std = np.empty((n_new, self.k))
+        for c in range(self.k):
+            Kem = self.kernels_[c](X, self.Z_)
+            raw_mean[:, c] = Kem @ self._coef[c]
+            if return_std:
+                v = solve_triangular(self._Lmm[c], Kem.T, lower=True)
+                u = solve_triangular(self._Lq[c], Kem.T, lower=True)
+                var = (
+                    self.kernels_[c].diag(X)
+                    - np.sum(v**2, axis=0)
+                    + np.sum(u**2, axis=0)
+                )
+                raw_std[:, c] = np.sqrt(np.maximum(var, 1e-10))
+        mean: np.ndarray = (raw_mean - self.raw_mean_) @ self.whiten_
+        if return_std:
+            var_prop = raw_std**2 @ (self.whiten_**2)
+            return mean, np.sqrt(var_prop)
+        return mean
+
+
 class GPCCA(BaseModel):
     r"""GPCCA — nonlinear multiview CCA with Gaussian-process encoders.
 
@@ -241,7 +425,9 @@ class GPCCA(BaseModel):
         A GP over the raw feature vector scales cubically in the number of
         training samples (exact GP inference); for very large datasets
         expect fitting to be markedly slower than
-        :class:`~cca_zoo.gam.GAMCCA` or :class:`~cca_zoo.tree.TreeCCA`.
+        :class:`~cca_zoo.gam.GAMCCA` or :class:`~cca_zoo.tree.TreeCCA`
+        unless ``n_inducing`` is set (see below), which trades some
+        approximation error for linear-in-``n_samples`` scaling.
 
     References:
         Rasmussen, C. E., & Williams, C. K. I. (2006). Gaussian Processes
@@ -265,8 +451,18 @@ class GPCCA(BaseModel):
         hess_floor_percentile: Percentile (0-100) of each round's raw
             diagonal-Hessian values used to floor them (see
             :func:`~cca_zoo._utils._ey.ey_diag_hessian`). Default is 90.0.
+        n_inducing: Number of inducing points for the sparse (Deterministic
+            Training Conditional) approximation described above. ``None``
+            (the default) uses exact GP inference — appropriate for
+            datasets up to a few thousand samples. For larger datasets,
+            set this to a few hundred inducing points to make fitting
+            scale as $O(n \, \text{n\_inducing}^2)$ instead of $O(n^3)$;
+            larger values trade speed for a closer approximation to the
+            exact posterior. Values at or above the number of training
+            samples fall back to exact inference automatically.
         random_state: Seed for drawing the random-orthogonal initial
-            embedding. Default is 0.
+            embedding, and (if ``n_inducing`` is set) for selecting
+            inducing points. Default is 0.
 
     Example:
         >>> import numpy as np
@@ -276,6 +472,8 @@ class GPCCA(BaseModel):
         >>> model = GPCCA(latent_dimensions=1).fit([X1, X2])
         >>> scores = model.transform([X1, X2])
         >>> means, stds = model.transform([X1, X2], return_std=True)
+        >>> # For larger datasets, cap inference cost with inducing points:
+        >>> big_model = GPCCA(latent_dimensions=1, n_inducing=200)
     """
 
     _parameter_constraints: ClassVar[dict[str, list[Any]]] = {
@@ -284,6 +482,7 @@ class GPCCA(BaseModel):
         "max_outer_iter": [Interval(Integral, 1, None, closed="left")],
         "tol": [Interval(Real, 0, None, closed="neither")],
         "hess_floor_percentile": [Interval(Real, 0, 100, closed="both")],
+        "n_inducing": [None, Interval(Integral, 2, None, closed="left")],
     }
 
     def __init__(
@@ -294,6 +493,7 @@ class GPCCA(BaseModel):
         max_outer_iter: int = 4,
         tol: float = 1e-3,
         hess_floor_percentile: float = 90.0,
+        n_inducing: int | None = None,
         random_state: int = 0,
     ) -> None:
         super().__init__(latent_dimensions=latent_dimensions, center=center)
@@ -301,6 +501,7 @@ class GPCCA(BaseModel):
         self.max_outer_iter = max_outer_iter
         self.tol = tol
         self.hess_floor_percentile = hess_floor_percentile
+        self.n_inducing = n_inducing
         self.random_state = random_state
 
     def fit(self, views: list[ArrayLike], y: None = None) -> GPCCA:
@@ -324,7 +525,13 @@ class GPCCA(BaseModel):
         n_minus_1 = n - 1
 
         rng = np.random.default_rng(self.random_state)
-        encoders = [_GpEncoder(X, k) for X in views_]
+        use_sparse = self.n_inducing is not None and self.n_inducing < n
+        encoders: list[_GpEncoder] = [
+            _SparseGpEncoder(X, k, self.n_inducing, self.random_state)  # type: ignore[arg-type]
+            if use_sparse
+            else _GpEncoder(X, k)
+            for X in views_
+        ]
         representations = []
         for X in views_:
             bm, _ = random_orthogonal_embedding(X, k, rng)

--- a/cca_zoo/tree/_treecca.py
+++ b/cca_zoo/tree/_treecca.py
@@ -10,7 +10,11 @@ from numpy.typing import ArrayLike
 from sklearn.utils.validation import check_is_fitted
 
 from cca_zoo._base import BaseModel
-from cca_zoo._utils._ey import ey_grad_z
+from cca_zoo._utils._ey import (
+    ey_grad_z,
+    random_orthogonal_embedding,
+    rescale_grads_to_target_std,
+)
 from cca_zoo._utils._validation import validate_views
 
 try:
@@ -24,56 +28,20 @@ except ImportError:
 def _rescale_to_target_std(
     grads: list[np.ndarray], target_std: float = 0.1
 ) -> list[np.ndarray]:
-    """Rescale a set of per-view gradients to a common target standard deviation.
+    """As :func:`cca_zoo._utils._ey.rescale_grads_to_target_std`, cast to float32.
 
-    Boosted-tree leaf values are well-conditioned only for a roughly-fixed
-    gradient scale, so the exact (analytic) EY gradient is rescaled by a
-    single shared scalar before being used as a custom-objective target.
-    Since the same scalar is applied to every view, this changes only the
-    effective step size, not the gradient's direction or relative
-    cross-view magnitudes.
+    ``float32`` is required for XGBoost/LightGBM custom objectives.
 
     Args:
         grads: One gradient array per view, each (n_samples, k).
         target_std: Target standard deviation. Default is 0.1.
 
     Returns:
-        List of rescaled gradients, dtype ``float32`` (required for
-        XGBoost/LightGBM custom objectives).
+        List of rescaled gradients, dtype ``float32``.
     """
-    scale = max(max(float(g.std()) for g in grads), 1e-6)
-    return [(g / scale * target_std).astype(np.float32) for g in grads]
-
-
-def _random_orthogonal_base_margin(
-    Xc: np.ndarray, k: int, rng: np.random.Generator
-) -> tuple[np.ndarray, np.ndarray]:
-    """Unit-variance random-orthogonal initial embedding and its projection.
-
-    Draws ``k`` random orthogonal directions in feature space (independent of
-    the data's principal directions) and rescales them so each initial
-    component has unit variance. The unit-variance scaling is what matters
-    for a well-conditioned, non-vanishing EY gradient from round zero;
-    orthogonality keeps the initial cross-component covariance at zero.
-
-    Args:
-        Xc: Mean-centred training view, shape (n_samples, n_features).
-        k: Number of components. Must not exceed ``n_features``.
-        rng: Random generator used to draw the orthogonal directions.
-
-    Returns:
-        Tuple ``(base_margin, projection)``: ``base_margin`` has shape
-        (n_samples, k) and is the initial embedding for training;
-        ``projection`` has shape (n_features, k) and reproduces the same
-        unit-variance embedding for unseen data via ``Xc_new @ projection``.
-    """
-    n, p = Xc.shape
-    W, _ = np.linalg.qr(rng.standard_normal((p, k)))
-    Z = Xc @ W
-    scale = np.linalg.norm(Z, axis=0, keepdims=True) / np.sqrt(n - 1)
-    projection = (W / scale).astype(np.float32)
-    base_margin = (Z / scale).astype(np.float32)
-    return base_margin, projection
+    return [
+        g.astype(np.float32) for g in rescale_grads_to_target_std(grads, target_std)
+    ]
 
 
 class _Encoder:
@@ -334,7 +302,7 @@ class TreeCCA(BaseModel):
         base_margins = []
         projections = []
         for X in views_:
-            bm, proj = _random_orthogonal_base_margin(X, k, rng)
+            bm, proj = random_orthogonal_embedding(X, k, rng)
             base_margins.append(bm)
             projections.append(proj)
         self._projections_: list[np.ndarray] = projections

--- a/docs/api/gam.md
+++ b/docs/api/gam.md
@@ -1,7 +1,7 @@
 # cca_zoo.gam
 
 Generalized-additive-model (GAM) nonlinear CCA methods. Built entirely on scikit-learn's own
-`SplineTransformer`/`Ridge` — no optional dependency required.
+`SplineTransformer`/`Ridge`/`RidgeCV` — no optional dependency required.
 
 ---
 

--- a/docs/api/gam.md
+++ b/docs/api/gam.md
@@ -1,7 +1,7 @@
 # cca_zoo.gam
 
-Generalized-additive-model (GAM) nonlinear CCA methods. Pure numpy/scipy — no optional
-dependency required.
+Generalized-additive-model (GAM) nonlinear CCA methods. Built entirely on scikit-learn's own
+`SplineTransformer`/`Ridge` — no optional dependency required.
 
 ---
 

--- a/docs/api/gam.md
+++ b/docs/api/gam.md
@@ -1,0 +1,8 @@
+# cca_zoo.gam
+
+Generalized-additive-model (GAM) nonlinear CCA methods. Pure numpy/scipy — no optional
+dependency required.
+
+---
+
+::: cca_zoo.gam.GAMCCA

--- a/docs/api/gp.md
+++ b/docs/api/gp.md
@@ -1,0 +1,8 @@
+# cca_zoo.gp
+
+Gaussian-process (GP) nonlinear CCA methods. Built entirely on scikit-learn's own
+`GaussianProcessRegressor`/`RBF`/`ConstantKernel` — no optional dependency required.
+
+---
+
+::: cca_zoo.gp.GPCCA

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,6 +7,7 @@ Complete API documentation auto-generated from source docstrings.
 | [`cca_zoo.linear`](linear.md) | CCA, rCCA, PLS, MCCA, GCCA, TCCA, gradient and sparse variants |
 | [`cca_zoo.nonparametric`](nonparametric.md) | KCCA, KGCCA, KTCCA |
 | [`cca_zoo.tree`](tree.md) | TreeCCA |
+| [`cca_zoo.gam`](gam.md) | GAMCCA |
 | [`cca_zoo.deep`](deep.md) | DCCA and variants, objectives |
 | [`cca_zoo.probabilistic`](probabilistic.md) | GFA, ProbabilisticCCA, VariationalBayesCCA |
 | [`cca_zoo.datasets`](datasets.md) | JointData, toy loaders |

--- a/docs/user-guide/gam.md
+++ b/docs/user-guide/gam.md
@@ -1,9 +1,10 @@
 # GAM Methods
 
 The `cca_zoo.gam` module provides `GAMCCA`, a nonlinear multiview CCA method that uses a
-generalized additive model (GAM) — one smooth univariate spline per input feature — as the
-per-view encoder. It has no optional dependency; it only needs numpy/scipy, already required by
-`cca_zoo`.
+generalized additive model (GAM) — one smooth univariate B-spline per input feature — as the
+per-view encoder. It has no optional dependency: the spline basis and its penalised fit are built
+entirely from scikit-learn's own `SplineTransformer` and `Ridge`, both already required by
+`cca_zoo`, rather than reimplemented from scratch.
 
 ---
 
@@ -20,19 +21,21 @@ $$
 
 where, for embeddings $Z_i = f_i(X_i)$, $C$ is the mean pairwise cross-covariance (including
 $i = j$ terms) and $V$ the mean auto-covariance across all views. `GAMCCA` uses a generalized
-additive model — $f_i(x) = \sum_j s_j(x_j)$, one cubic-regression-spline term per input
-feature — in place of a linear map (`CCA_EY`) or a boosted-tree ensemble (`TreeCCA`) as the
-function class for each $f_i$.
+additive model — $f_i(x) = \sum_j s_j(x_j)$, one B-spline term per input feature — in place of a
+linear map (`CCA_EY`) or a boosted-tree ensemble (`TreeCCA`) as the function class for each
+$f_i$. The per-feature basis comes from `sklearn.preprocessing.SplineTransformer` (one contiguous
+block of B-spline columns per feature, giving the additive structure directly) and each round's
+penalised fit from `sklearn.linear_model.Ridge` — both scikit-learn's own, already-required
+implementations, not reimplemented here.
 
 Training proceeds by alternating (Gauss-Seidel) L2Boosting (Bühlmann & Yu, 2003): each round, for
 every view in turn, the EY-loss gradient is computed from the current embeddings, rescaled to a
 fixed target standard deviation (the analytic gradient's natural scale is far smaller than a
 well-conditioned regression target — the same fix `TreeCCA` applies to its own boosters), and
-fit — *jointly across all of that view's features* — by a single ridge-penalised regression onto
-the concatenated per-feature spline basis. The fit is shrunk by `learning_rate` and added to the
-running per-feature coefficients. With `gauss_seidel=True` (the default) the gradient is
-recomputed from the freshest embeddings before moving to the next view. Encoders start from a
-random-orthogonal, unit-variance initial embedding per view, exactly as `TreeCCA` does.
+ridge-fit onto that view's fixed spline basis. The fit is shrunk by `learning_rate` and added to a
+running total. With `gauss_seidel=True` (the default) the gradient is recomputed from the
+freshest embeddings before moving to the next view. Encoders start from a random-orthogonal,
+unit-variance initial embedding per view, exactly as `TreeCCA` does.
 
 Because each latent component decomposes exactly into one additive term per input feature, the
 fitted shape of any feature's contribution is available directly via `model.shape_function(...)`
@@ -51,7 +54,8 @@ noisy linear copy of `z ** 2` (a smooth but non-monotonic transform, so no linea
 either view's raw features can align with the other — `rCCA` gets essentially nothing). At a
 matched budget of 150 boosting rounds, `GAMCCA` reaches a held-out canonical correlation of about
 0.97, versus about 0.60 for `TreeCCA` — which does not reach that level even at 600 rounds (about
-0.90).
+0.90) — and `GAMCCA` is also markedly cheaper per round, since a ridge-regularised least-squares
+solve is far cheaper than growing a tree.
 
 If cross-view structure instead depends on an *interaction* between two features of the same view
 (e.g. $x_1 x_2$), a GAM's additive structure cannot represent that the way a tree's multivariate
@@ -97,9 +101,9 @@ score.
 | Parameter | Description |
 |---|---|
 | `n_estimators` | Boosting rounds. Higher values fit more complex relationships but risk overfitting and cost more time. |
-| `n_knots` | Interior knots per feature's cubic regression spline; basis dimension is `4 + n_knots`. More knots allow wigglier per-feature curves. |
+| `n_knots` | Knots per feature's B-spline term, passed straight through to `SplineTransformer(n_knots=...)`. More knots allow wigglier per-feature curves. |
 | `learning_rate` | Boosting shrinkage applied to each round's ridge fit. |
-| `ridge` | Ridge penalty for each round's per-view spline fit (applied after normalising every basis column to unit norm, so it penalises all features/terms comparably). The main defence against overfitting a single view's noise — increase it for smoother, less wiggly curves. |
+| `ridge` | Ridge penalty for each round's per-view spline fit, passed straight through to `Ridge(alpha=...)`. The main defence against overfitting a single view's noise — increase it for smoother, less wiggly curves. |
 | `gauss_seidel` | Use freshly-updated view-1 embeddings when computing view 2's gradient each round (default `True`); set `False` for Jacobi-style stale updates. |
 | `random_state` | Seed for the random-orthogonal initial embedding. |
 
@@ -115,4 +119,5 @@ Hyperparameters are best selected by cross-validation with `GridSearchCV` from
   initialisation draws that many orthogonal directions in feature space).
 - Unlike `KCCA`, `GAMCCA` does not store the training data for inference — new data is passed
   directly through the fitted per-feature splines, so `transform` on held-out data is inexpensive.
-- No optional dependency is required (unlike `cca_zoo.tree`, which needs `xgboost`/`lightgbm`).
+- No optional dependency is required (unlike `cca_zoo.tree`, which needs `xgboost`/`lightgbm`):
+  `GAMCCA` is built entirely on `scikit-learn`'s `SplineTransformer` and `Ridge`.

--- a/docs/user-guide/gam.md
+++ b/docs/user-guide/gam.md
@@ -3,8 +3,8 @@
 The `cca_zoo.gam` module provides `GAMCCA`, a nonlinear multiview CCA method that uses a
 generalized additive model (GAM) — one smooth univariate B-spline per input feature — as the
 per-view encoder. It has no optional dependency: the spline basis and its penalised fit are built
-entirely from scikit-learn's own `SplineTransformer` and `Ridge`, both already required by
-`cca_zoo`, rather than reimplemented from scratch.
+entirely from scikit-learn's own `SplineTransformer`, `Ridge` and `RidgeCV`, all already required
+by `cca_zoo`, rather than reimplemented from scratch.
 
 ---
 
@@ -23,19 +23,28 @@ where, for embeddings $Z_i = f_i(X_i)$, $C$ is the mean pairwise cross-covarianc
 $i = j$ terms) and $V$ the mean auto-covariance across all views. `GAMCCA` uses a generalized
 additive model — $f_i(x) = \sum_j s_j(x_j)$, one B-spline term per input feature — in place of a
 linear map (`CCA_EY`) or a boosted-tree ensemble (`TreeCCA`) as the function class for each
-$f_i$. The per-feature basis comes from `sklearn.preprocessing.SplineTransformer` (one contiguous
-block of B-spline columns per feature, giving the additive structure directly) and each round's
-penalised fit from `sklearn.linear_model.Ridge` — both scikit-learn's own, already-required
-implementations, not reimplemented here.
+$f_i$.
 
-Training proceeds by alternating (Gauss-Seidel) L2Boosting (Bühlmann & Yu, 2003): each round, for
-every view in turn, the EY-loss gradient is computed from the current embeddings, rescaled to a
-fixed target standard deviation (the analytic gradient's natural scale is far smaller than a
-well-conditioned regression target — the same fix `TreeCCA` applies to its own boosters), and
-ridge-fit onto that view's fixed spline basis. The fit is shrunk by `learning_rate` and added to a
-running total. With `gauss_seidel=True` (the default) the gradient is recomputed from the
-freshest embeddings before moving to the next view. Encoders start from a random-orthogonal,
-unit-variance initial embedding per view, exactly as `TreeCCA` does.
+Unlike those models, which reach the EY loss's optimum by many small (stochastic-)gradient steps,
+`GAMCCA` fits it the way GAM software such as R's `mgcv` fits an ordinary GAM, applied directly to
+the EY loss instead of a per-observation likelihood:
+
+1. **Inner loop — P-IRLS.** For the *current, fixed* smoothing parameters, repeatedly take a
+   Newton step on the EY loss for each view in turn: form a working response
+   $Z_i - \nabla_i / h_i$ from the analytic EY gradient $\nabla_i$ and a diagonal Hessian weight
+   $h_i$, and ridge-regress it onto that view's fixed B-spline basis (`sklearn.linear_model.Ridge`).
+   Cycle through every view until the EY loss itself stops moving.
+2. **Outer loop — GCV-style smoothing-parameter search.** Only once the inner loop has converged,
+   re-select each view's smoothing parameter with `sklearn.linear_model.RidgeCV`'s efficient
+   leave-one-out cross-validation (the same statistical job GCV/REML do in `mgcv`) at that
+   converged state, then re-run the inner loop with the new parameters. Repeat until the smoothing
+   parameters stabilise too.
+
+This is a deliberate departure from `TreeCCA`'s boosting recipe, which exists because a tree
+ensemble has no closed-form fit to a moving target and so *must* be built up from many small
+shrunk steps. A ridge-penalised spline fit has no such constraint, so `GAMCCA` has no
+`learning_rate` or `n_estimators` to tune — each view's smoothing strength is chosen
+automatically, exactly as it would be fitting any other GAM.
 
 Because each latent component decomposes exactly into one additive term per input feature, the
 fitted shape of any feature's contribution is available directly via `model.shape_function(...)`
@@ -45,17 +54,15 @@ single importance score, and smooth by construction rather than a step function.
 **When to use:** Nonlinear multiview CCA where the true per-feature relationship is expected to
 be *smooth* (rather than needing feature interactions or sharp thresholds) — a GAM's smoothness
 assumption is then a genuine inductive-bias advantage, not just a cosmetic one. On such data
-`GAMCCA` can reach a given held-out canonical correlation in far fewer boosting rounds than
-`TreeCCA`, and generalise better at a matched round budget, because its basis represents a smooth
-curve (e.g. a parabola) directly instead of approximating it with many small steps. See
+`GAMCCA` reaches a higher held-out canonical correlation than `TreeCCA`, converges without any
+round-count tuning, and is markedly cheaper per fit (a ridge solve is far cheaper than growing a
+tree ensemble). See
 `tests/gam/test_gamcca.py::test_gamcca_outperforms_linear_and_tree_on_smooth_nonmonotonic_data`
 for a worked example: view 1 is a noisy linear copy of a shared latent factor `z`; view 2 is a
 noisy linear copy of `z ** 2` (a smooth but non-monotonic transform, so no linear combination of
-either view's raw features can align with the other — `rCCA` gets essentially nothing). At a
-matched budget of 150 boosting rounds, `GAMCCA` reaches a held-out canonical correlation of about
-0.97, versus about 0.60 for `TreeCCA` — which does not reach that level even at 600 rounds (about
-0.90) — and `GAMCCA` is also markedly cheaper per round, since a ridge-regularised least-squares
-solve is far cheaper than growing a tree.
+either view's raw features can align with the other — `rCCA` gets essentially nothing). `GAMCCA`
+reaches a held-out canonical correlation of about 0.94, versus about 0.60 for `TreeCCA` at 150
+boosting rounds (`TreeCCA` needs 600+ rounds to approach 0.90).
 
 If cross-view structure instead depends on an *interaction* between two features of the same view
 (e.g. $x_1 x_2$), a GAM's additive structure cannot represent that the way a tree's multivariate
@@ -68,12 +75,12 @@ splits can — prefer `TreeCCA` there.
 ```python
 from cca_zoo.gam import GAMCCA
 
-model = GAMCCA(latent_dimensions=2, n_estimators=150).fit([X1, X2])
+model = GAMCCA(latent_dimensions=2).fit([X1, X2])
 z1, z2 = model.transform([X1, X2])
 corrs = model.score([X1, X2])
 
 # GAMCCA also supports more than two views
-model3 = GAMCCA(latent_dimensions=2, n_estimators=150).fit([X1, X2, X3])
+model3 = GAMCCA(latent_dimensions=2).fit([X1, X2, X3])
 ```
 
 ## Inspecting fitted shape functions
@@ -92,7 +99,8 @@ shape = model.shape_function(view=0, feature=0, x=x_grid)  # (200, 1)
 
 `shape` is that feature's contribution alone, in the units of the latent component — plot it
 against `x_grid` to see the exact fitted curve for that feature, rather than a single importance
-score.
+score. Summing every feature's `shape_function` at the training values reproduces
+`model.encoders_[view].predict()` exactly.
 
 ---
 
@@ -100,15 +108,18 @@ score.
 
 | Parameter | Description |
 |---|---|
-| `n_estimators` | Boosting rounds. Higher values fit more complex relationships but risk overfitting and cost more time. |
 | `n_knots` | Knots per feature's B-spline term, passed straight through to `SplineTransformer(n_knots=...)`. More knots allow wigglier per-feature curves. |
-| `learning_rate` | Boosting shrinkage applied to each round's ridge fit. |
-| `ridge` | Ridge penalty for each round's per-view spline fit, passed straight through to `Ridge(alpha=...)`. The main defence against overfitting a single view's noise — increase it for smoother, less wiggly curves. |
-| `gauss_seidel` | Use freshly-updated view-1 embeddings when computing view 2's gradient each round (default `True`); set `False` for Jacobi-style stale updates. |
+| `alphas` | Candidate smoothing parameters searched by `RidgeCV` in the outer loop. Default is `numpy.logspace(-6, 3, 10)`. |
+| `max_inner_iter` | Cap on P-IRLS rounds (one cycle through every view) per outer iteration. In practice the inner loop converges well before this in typical cases. |
+| `max_outer_iter` | Cap on smoothing-parameter re-selection rounds. |
+| `tol` | Inner-loop convergence tolerance, on the change in the EY loss between successive full passes over all views. |
+| `hess_floor_percentile` | Percentile (0-100) of each round's raw diagonal-Hessian values used to floor them — self-calibrating damping against the Hessian's poor conditioning near the loss's own fixed point (see the class docstring for why). Default is 90. |
 | `random_state` | Seed for the random-orthogonal initial embedding. |
 
-Hyperparameters are best selected by cross-validation with `GridSearchCV` from
-`cca_zoo.model_selection`, as for other models.
+Because the smoothing parameter is selected automatically, `GAMCCA` needs far less manual
+hyperparameter search than `TreeCCA`; `n_knots` and `hess_floor_percentile` are the two knobs
+worth adjusting if the defaults underperform, and both are stable across a wide range of data
+sizes and scales in practice.
 
 ---
 
@@ -120,4 +131,4 @@ Hyperparameters are best selected by cross-validation with `GridSearchCV` from
 - Unlike `KCCA`, `GAMCCA` does not store the training data for inference — new data is passed
   directly through the fitted per-feature splines, so `transform` on held-out data is inexpensive.
 - No optional dependency is required (unlike `cca_zoo.tree`, which needs `xgboost`/`lightgbm`):
-  `GAMCCA` is built entirely on `scikit-learn`'s `SplineTransformer` and `Ridge`.
+  `GAMCCA` is built entirely on `scikit-learn`'s `SplineTransformer`, `Ridge` and `RidgeCV`.

--- a/docs/user-guide/gam.md
+++ b/docs/user-guide/gam.md
@@ -1,0 +1,118 @@
+# GAM Methods
+
+The `cca_zoo.gam` module provides `GAMCCA`, a nonlinear multiview CCA method that uses a
+generalized additive model (GAM) — one smooth univariate spline per input feature — as the
+per-view encoder. It has no optional dependency; it only needs numpy/scipy, already required by
+`cca_zoo`.
+
+---
+
+## Background
+
+`GAMCCA` maximises the same unconstrained Eckart-Young (EY) objective used by the stochastic
+`*_EY` models in `cca_zoo.linear`, by `DCCA_EY` in `cca_zoo.deep`, and by `TreeCCA` in
+`cca_zoo.tree` (the numpy-based models share the exact same implementation, in
+`cca_zoo._utils._ey`):
+
+$$
+\mathcal{L}_{EY} = -2 \operatorname{tr}(C) + \operatorname{tr}(V V)
+$$
+
+where, for embeddings $Z_i = f_i(X_i)$, $C$ is the mean pairwise cross-covariance (including
+$i = j$ terms) and $V$ the mean auto-covariance across all views. `GAMCCA` uses a generalized
+additive model — $f_i(x) = \sum_j s_j(x_j)$, one cubic-regression-spline term per input
+feature — in place of a linear map (`CCA_EY`) or a boosted-tree ensemble (`TreeCCA`) as the
+function class for each $f_i$.
+
+Training proceeds by alternating (Gauss-Seidel) L2Boosting (Bühlmann & Yu, 2003): each round, for
+every view in turn, the EY-loss gradient is computed from the current embeddings, rescaled to a
+fixed target standard deviation (the analytic gradient's natural scale is far smaller than a
+well-conditioned regression target — the same fix `TreeCCA` applies to its own boosters), and
+fit — *jointly across all of that view's features* — by a single ridge-penalised regression onto
+the concatenated per-feature spline basis. The fit is shrunk by `learning_rate` and added to the
+running per-feature coefficients. With `gauss_seidel=True` (the default) the gradient is
+recomputed from the freshest embeddings before moving to the next view. Encoders start from a
+random-orthogonal, unit-variance initial embedding per view, exactly as `TreeCCA` does.
+
+Because each latent component decomposes exactly into one additive term per input feature, the
+fitted shape of any feature's contribution is available directly via `model.shape_function(...)`
+— the GAM analogue of `TreeCCA`'s split-gain feature importance, but an exact curve rather than a
+single importance score, and smooth by construction rather than a step function.
+
+**When to use:** Nonlinear multiview CCA where the true per-feature relationship is expected to
+be *smooth* (rather than needing feature interactions or sharp thresholds) — a GAM's smoothness
+assumption is then a genuine inductive-bias advantage, not just a cosmetic one. On such data
+`GAMCCA` can reach a given held-out canonical correlation in far fewer boosting rounds than
+`TreeCCA`, and generalise better at a matched round budget, because its basis represents a smooth
+curve (e.g. a parabola) directly instead of approximating it with many small steps. See
+`tests/gam/test_gamcca.py::test_gamcca_outperforms_linear_and_tree_on_smooth_nonmonotonic_data`
+for a worked example: view 1 is a noisy linear copy of a shared latent factor `z`; view 2 is a
+noisy linear copy of `z ** 2` (a smooth but non-monotonic transform, so no linear combination of
+either view's raw features can align with the other — `rCCA` gets essentially nothing). At a
+matched budget of 150 boosting rounds, `GAMCCA` reaches a held-out canonical correlation of about
+0.97, versus about 0.60 for `TreeCCA` — which does not reach that level even at 600 rounds (about
+0.90).
+
+If cross-view structure instead depends on an *interaction* between two features of the same view
+(e.g. $x_1 x_2$), a GAM's additive structure cannot represent that the way a tree's multivariate
+splits can — prefer `TreeCCA` there.
+
+---
+
+## Basic usage
+
+```python
+from cca_zoo.gam import GAMCCA
+
+model = GAMCCA(latent_dimensions=2, n_estimators=150).fit([X1, X2])
+z1, z2 = model.transform([X1, X2])
+corrs = model.score([X1, X2])
+
+# GAMCCA also supports more than two views
+model3 = GAMCCA(latent_dimensions=2, n_estimators=150).fit([X1, X2, X3])
+```
+
+## Inspecting fitted shape functions
+
+`GAMCCA` has no linear weight matrices, so `model.weights` raises `NotImplementedError`. Use
+`shape_function` instead to evaluate a single feature's fitted additive term directly:
+
+```python
+import numpy as np
+
+model = GAMCCA(latent_dimensions=1).fit([X1, X2])
+
+x_grid = np.linspace(X1[:, 0].min(), X1[:, 0].max(), 200)
+shape = model.shape_function(view=0, feature=0, x=x_grid)  # (200, 1)
+```
+
+`shape` is that feature's contribution alone, in the units of the latent component — plot it
+against `x_grid` to see the exact fitted curve for that feature, rather than a single importance
+score.
+
+---
+
+## Key parameters
+
+| Parameter | Description |
+|---|---|
+| `n_estimators` | Boosting rounds. Higher values fit more complex relationships but risk overfitting and cost more time. |
+| `n_knots` | Interior knots per feature's cubic regression spline; basis dimension is `4 + n_knots`. More knots allow wigglier per-feature curves. |
+| `learning_rate` | Boosting shrinkage applied to each round's ridge fit. |
+| `ridge` | Ridge penalty for each round's per-view spline fit (applied after normalising every basis column to unit norm, so it penalises all features/terms comparably). The main defence against overfitting a single view's noise — increase it for smoother, less wiggly curves. |
+| `gauss_seidel` | Use freshly-updated view-1 embeddings when computing view 2's gradient each round (default `True`); set `False` for Jacobi-style stale updates. |
+| `random_state` | Seed for the random-orthogonal initial embedding. |
+
+Hyperparameters are best selected by cross-validation with `GridSearchCV` from
+`cca_zoo.model_selection`, as for other models.
+
+---
+
+## Practical notes
+
+- `GAMCCA` supports 2 or more views.
+- `latent_dimensions` must not exceed the number of features in any view (the random-orthogonal
+  initialisation draws that many orthogonal directions in feature space).
+- Unlike `KCCA`, `GAMCCA` does not store the training data for inference — new data is passed
+  directly through the fitted per-feature splines, so `transform` on held-out data is inexpensive.
+- No optional dependency is required (unlike `cca_zoo.tree`, which needs `xgboost`/`lightgbm`).

--- a/docs/user-guide/gp.md
+++ b/docs/user-guide/gp.md
@@ -1,0 +1,108 @@
+# GP Methods
+
+The `cca_zoo.gp` module provides `GPCCA`, a nonlinear multiview CCA method that uses a
+Gaussian process with a joint (non-additive) kernel as the per-view encoder. It has no optional
+dependency: the kernel and its fit are built entirely from scikit-learn's own
+`GaussianProcessRegressor`, `RBF` and `ConstantKernel`, all already required by `cca_zoo`.
+
+---
+
+## Background
+
+`GPCCA` maximises the same unconstrained Eckart-Young (EY) objective used by the stochastic
+`*_EY` models in `cca_zoo.linear`, by `DCCA_EY` in `cca_zoo.deep`, by `TreeCCA` in `cca_zoo.tree`,
+and by `GAMCCA` in `cca_zoo.gam` (all share the exact same implementation, in
+`cca_zoo._utils._ey`):
+
+$$
+\mathcal{L}_{EY} = -2 \operatorname{tr}(C) + \operatorname{tr}(V V)
+$$
+
+where, for embeddings $Z_i = f_i(X_i)$, $C$ is the mean pairwise cross-covariance (including
+$i = j$ terms) and $V$ the mean auto-covariance across all views. Where `GAMCCA` sums one
+univariate B-spline term per input feature — additive, and so structurally unable to represent an
+interaction between two features of the same view — `GPCCA` fits a Gaussian process with an ARD
+(per-feature-lengthscale) RBF kernel directly over each view's *raw, joint* feature vector: a
+genuine, non-additive function of all of that view's features at once. As a Bayesian model it
+also comes with calibrated predictive uncertainty for free.
+
+`GPCCA` is fit with the same inner/outer split as `GAMCCA`'s P-IRLS/GCV recipe, with the GP's own
+machinery in place of `Ridge`/`RidgeCV`:
+
+1. **Inner loop — fixed-kernel Newton steps.** For the *current* kernel hyperparameters,
+   repeatedly take a Newton step on the EY loss for each view in turn: form a working response
+   $Z_i - \nabla_i / h_i$ from the analytic EY gradient $\nabla_i$ and a diagonal Hessian weight
+   $h_i$, and fit it with `GaussianProcessRegressor` (`optimizer=None`, so the kernel is held
+   fixed), passing $h_i$ as the GP's per-sample `alpha` (heteroscedastic observation noise). Cycle
+   through every view until the EY loss itself stops moving.
+2. **Outer loop — marginal-likelihood kernel search.** Only once the inner loop has converged,
+   re-fit each view's kernel hyperparameters (lengthscales, signal variance) at that converged
+   working response via the GP's own default log-marginal-likelihood optimisation — the direct GP
+   analogue of GCV/REML smoothing-parameter search in `GAMCCA`. Repeat until the kernel
+   hyperparameters stabilise too.
+
+**When to use:** Nonlinear multiview CCA where cross-view structure depends on a genuine
+*interaction* between two or more features of the same view (e.g. $x_1 x_2$), which an additive
+GAM cannot represent and which a tree ensemble can only approximate via multivariate splits (and,
+at default settings, may be starved of joint feature access — see `TreeCCA`'s `colsample_bytree`).
+A GP with a joint kernel represents such an interaction directly. When the true relationship is
+smooth and *additive*, `GAMCCA` is typically a cheaper and equally accurate choice; a GP over the
+raw feature vector scales cubically in the number of training samples (exact GP inference), so
+expect fitting to be markedly slower than `GAMCCA` or `TreeCCA` on large datasets.
+
+---
+
+## Basic usage
+
+```python
+from cca_zoo.gp import GPCCA
+
+model = GPCCA(latent_dimensions=1).fit([X1, X2])
+z1, z2 = model.transform([X1, X2])
+corrs = model.score([X1, X2])
+
+# GPCCA also supports more than two views
+model3 = GPCCA(latent_dimensions=1).fit([X1, X2, X3])
+```
+
+## Predictive uncertainty
+
+Because each per-component encoder is a Gaussian process, `transform` can return each latent
+component's posterior standard deviation alongside its mean:
+
+```python
+means, stds = model.transform([X1, X2], return_std=True)
+```
+
+`stds[i]` has the same shape as `means[i]` (`(n_samples, latent_dimensions)`) and is the posterior
+standard deviation of view `i`'s latent component, propagated through the whitening transform —
+larger away from the training data, smaller near it, exactly as for any other GP posterior.
+
+`GPCCA` has no linear weight matrices and no per-feature decomposition analogous to `GAMCCA`'s
+`shape_function` (the kernel is not additive across features), so `model.weights` raises
+`NotImplementedError`.
+
+---
+
+## Key parameters
+
+| Parameter | Description |
+|---|---|
+| `max_inner_iter` | Cap on fixed-kernel Newton rounds (one cycle through every view) per outer iteration. In practice the inner loop converges well before this in typical cases. |
+| `max_outer_iter` | Cap on kernel-hyperparameter re-selection rounds. |
+| `tol` | Inner-loop convergence tolerance, on the change in the EY loss between successive full passes over all views. |
+| `hess_floor_percentile` | Percentile (0-100) of each round's raw diagonal-Hessian values used to floor them — self-calibrating damping against the Hessian's poor conditioning near the loss's own fixed point (see `GAMCCA`'s class docstring for why). Default is 90. |
+| `random_state` | Seed for the random-orthogonal initial embedding. |
+
+---
+
+## Practical notes
+
+- `GPCCA` supports 2 or more views.
+- `latent_dimensions` must not exceed the number of features in any view (the random-orthogonal
+  initialisation draws that many orthogonal directions in feature space).
+- Exact GP inference is $O(n^3)$ in the number of training samples; for large datasets consider
+  `GAMCCA` (if the relationship is additive) or `TreeCCA` instead.
+- No optional dependency is required (unlike `cca_zoo.tree`, which needs `xgboost`/`lightgbm`):
+  `GPCCA` is built entirely on `scikit-learn`'s `GaussianProcessRegressor`, `RBF` and
+  `ConstantKernel`.

--- a/docs/user-guide/gp.md
+++ b/docs/user-guide/gp.md
@@ -84,6 +84,33 @@ larger away from the training data, smaller near it, exactly as for any other GP
 
 ---
 
+## Scaling to larger datasets: the sparse (inducing-point) approximation
+
+Exact GP inference costs $O(n^3)$ per Newton step — every `inner_step`/`outer_step` call redoes a
+full Cholesky factorisation of an $(n, n)$ matrix — which becomes impractical somewhere in the
+low thousands of samples. Setting `n_inducing` switches each encoder to the **Deterministic
+Training Conditional (DTC)** sparse approximation (Quiñonero-Candela & Rasmussen, 2005): the GP is
+conditioned on `n_inducing` inducing points — an actual, well-spread subset of the training rows,
+selected via `sklearn.cluster.kmeans_plusplus`'s seeding — and every posterior formula becomes a
+function of the $(n, m)$ and $(m, m)$ inducing-covariance matrices instead of the full $(n, n)$
+one, costing $O(n \, m^2 + m^3)$ instead of $O(n^3)$:
+
+```python
+model = GPCCA(latent_dimensions=1, n_inducing=200).fit([X1, X2])  # X1, X2 have many samples
+```
+
+Kernel hyperparameters are still selected by an *exact* marginal-likelihood fit — just on the
+`n_inducing` inducing rows alone, where it's cheap — while the actual working-response fit used to
+build each round's representation always uses *every* training row via the DTC formula, so no
+training signal is thrown away at the point that matters most. `n_inducing` values at or above the
+number of training samples are equivalent to (and internally fall back to) exact inference. Larger
+`n_inducing` trades speed for a closer approximation to the exact posterior; there's no universal
+default, since how many inducing points are "enough" depends on how smooth/low-rank the true
+underlying function is — start with a few hundred and check whether increasing it changes the
+held-out canonical correlation.
+
+---
+
 ## Key parameters
 
 | Parameter | Description |
@@ -92,7 +119,8 @@ larger away from the training data, smaller near it, exactly as for any other GP
 | `max_outer_iter` | Cap on kernel-hyperparameter re-selection rounds. |
 | `tol` | Inner-loop convergence tolerance, on the change in the EY loss between successive full passes over all views. |
 | `hess_floor_percentile` | Percentile (0-100) of each round's raw diagonal-Hessian values used to floor them — self-calibrating damping against the Hessian's poor conditioning near the loss's own fixed point (see `GAMCCA`'s class docstring for why). Default is 90. |
-| `random_state` | Seed for the random-orthogonal initial embedding. |
+| `n_inducing` | Number of inducing points for the sparse DTC approximation (see above). `None` (default) uses exact GP inference. |
+| `random_state` | Seed for the random-orthogonal initial embedding, and (if `n_inducing` is set) for selecting inducing points. |
 
 ---
 
@@ -101,8 +129,9 @@ larger away from the training data, smaller near it, exactly as for any other GP
 - `GPCCA` supports 2 or more views.
 - `latent_dimensions` must not exceed the number of features in any view (the random-orthogonal
   initialisation draws that many orthogonal directions in feature space).
-- Exact GP inference is $O(n^3)$ in the number of training samples; for large datasets consider
-  `GAMCCA` (if the relationship is additive) or `TreeCCA` instead.
+- Exact GP inference (`n_inducing=None`) is $O(n^3)$ in the number of training samples; set
+  `n_inducing` for datasets beyond a few thousand samples, or consider `GAMCCA` (if the
+  relationship is additive) or `TreeCCA` instead.
 - No optional dependency is required (unlike `cca_zoo.tree`, which needs `xgboost`/`lightgbm`):
-  `GPCCA` is built entirely on `scikit-learn`'s `GaussianProcessRegressor`, `RBF` and
-  `ConstantKernel`.
+  `GPCCA` is built entirely on `scikit-learn`'s `GaussianProcessRegressor`, `RBF`, `ConstantKernel`
+  and `kmeans_plusplus`.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -7,6 +7,7 @@ This guide explains each family of methods available in CCA-Zoo, their mathemati
 | [Linear Methods](linear.md) | Fast, interpretable, exact solutions for moderate-dimensional data |
 | [Nonparametric Methods](nonparametric.md) | Nonlinear relationships via kernel functions |
 | [Tree Methods](tree.md) | Nonlinear relationships with built-in, split-gain feature importance |
+| [GAM Methods](gam.md) | Smooth nonlinear (additive) relationships with per-feature shape functions |
 | [Deep Methods](deep.md) | Very high-dimensional data with complex structure (images, text) |
 | [Probabilistic CCA](probabilistic.md) | Uncertainty quantification; Bayesian treatment |
 | [Datasets](datasets.md) | Simulating and loading multiview datasets |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
       - Linear Methods: user-guide/linear.md
       - Nonparametric Methods: user-guide/nonparametric.md
       - Tree Methods: user-guide/tree.md
+      - GAM Methods: user-guide/gam.md
       - Deep Methods: user-guide/deep.md
       - Probabilistic CCA: user-guide/probabilistic.md
       - Datasets: user-guide/datasets.md
@@ -115,6 +116,7 @@ nav:
       - Linear: api/linear.md
       - Nonparametric: api/nonparametric.md
       - Tree: api/tree.md
+      - GAM: api/gam.md
       - Deep: api/deep.md
       - Probabilistic: api/probabilistic.md
       - Datasets: api/datasets.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
       - Nonparametric Methods: user-guide/nonparametric.md
       - Tree Methods: user-guide/tree.md
       - GAM Methods: user-guide/gam.md
+      - GP Methods: user-guide/gp.md
       - Deep Methods: user-guide/deep.md
       - Probabilistic CCA: user-guide/probabilistic.md
       - Datasets: user-guide/datasets.md
@@ -117,6 +118,7 @@ nav:
       - Nonparametric: api/nonparametric.md
       - Tree: api/tree.md
       - GAM: api/gam.md
+      - GP: api/gp.md
       - Deep: api/deep.md
       - Probabilistic: api/probabilistic.md
       - Datasets: api/datasets.md

--- a/tests/gam/test_gamcca.py
+++ b/tests/gam/test_gamcca.py
@@ -15,7 +15,6 @@ from cca_zoo.gam import GAMCCA
 
 
 def _make_model(latent_dimensions: int = 1, **kwargs: object) -> GAMCCA:
-    kwargs.setdefault("n_estimators", 10)
     return GAMCCA(latent_dimensions=latent_dimensions, **kwargs)
 
 
@@ -182,18 +181,6 @@ def test_center_false(two_views_small: list[np.ndarray]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# gauss_seidel toggle
-# ---------------------------------------------------------------------------
-
-
-def test_jacobi_variant_fit_completes(two_views_small: list[np.ndarray]) -> None:
-    """Fit completes with gauss_seidel=False (Jacobi updates)."""
-    model = _make_model(gauss_seidel=False).fit(two_views_small)
-    result = model.transform(two_views_small)
-    assert len(result) == 2
-
-
-# ---------------------------------------------------------------------------
 # encoders_ attribute
 # ---------------------------------------------------------------------------
 
@@ -265,7 +252,7 @@ def test_gamcca_finds_correlation_on_correlated_views(
     correlated_views: list[np.ndarray],
 ) -> None:
     """GAMCCA finds substantial correlation on views with shared latent structure."""
-    model = GAMCCA(latent_dimensions=1, n_estimators=100, random_state=0)
+    model = GAMCCA(latent_dimensions=1, random_state=0)
     s = model.fit(correlated_views).score(correlated_views)
     assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
 
@@ -278,7 +265,7 @@ def test_gamcca_finds_correlation_on_three_correlated_views() -> None:
         z @ rng.standard_normal((1, 5)) + 0.1 * rng.standard_normal((200, 5))
         for _ in range(3)
     ]
-    model = GAMCCA(latent_dimensions=1, n_estimators=150, random_state=0)
+    model = GAMCCA(latent_dimensions=1, random_state=0)
     s = model.fit(views).score(views)
     assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
 
@@ -294,9 +281,9 @@ def test_gamcca_outperforms_linear_and_tree_on_smooth_nonmonotonic_data() -> Non
     ``rCCA`` is expected to fail), while a per-view nonlinear encoder that
     (approximately) learns the "square" transform recovers near-perfect
     cross-view correlation. GAMCCA's B-spline basis represents a quadratic
-    almost exactly, so it should reach a given held-out correlation in far
-    fewer boosting rounds than TreeCCA's step-function tree ensembles, and
-    should out-generalise TreeCCA even at a matched round budget.
+    almost exactly and fits it via P-IRLS to convergence (no boosting-round
+    budget to match), so it should clearly beat TreeCCA at a generous but
+    fixed round count.
 
     Marked slow since it also requires TreeCCA's optional ``xgboost``
     dependency, not part of the base ``dev`` install.
@@ -314,14 +301,10 @@ def test_gamcca_outperforms_linear_and_tree_on_smooth_nonmonotonic_data() -> Non
     X1_tr, X1_te = X1[:n_train], X1[n_train:]
     X2_tr, X2_te = X2[:n_train], X2[n_train:]
 
-    n_estimators = 150
-
-    gam = GAMCCA(latent_dimensions=1, n_estimators=n_estimators, random_state=0)
+    gam = GAMCCA(latent_dimensions=1, random_state=0)
     gam_test = gam.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
 
-    tree = TreeCCA(
-        latent_dimensions=1, n_estimators=n_estimators, max_depth=5, random_state=0
-    )
+    tree = TreeCCA(latent_dimensions=1, n_estimators=150, max_depth=5, random_state=0)
     tree_test = tree.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
 
     rcca = rCCA(latent_dimensions=1, c=[0.3, 0.3])
@@ -332,7 +315,7 @@ def test_gamcca_outperforms_linear_and_tree_on_smooth_nonmonotonic_data() -> Non
     )
     assert gam_test > tree_test + 0.2, (
         f"Expected GAMCCA ({gam_test}) to clearly beat TreeCCA ({tree_test}) "
-        f"at a matched budget of {n_estimators} boosting rounds"
+        f"at a generous fixed round budget"
     )
     assert gam_test > rcca_test + 0.5, (
         f"Expected GAMCCA ({gam_test}) to clearly beat linear rCCA ({rcca_test})"

--- a/tests/gam/test_gamcca.py
+++ b/tests/gam/test_gamcca.py
@@ -1,9 +1,15 @@
-"""Tests for GAMCCA."""
+"""Tests for GAMCCA.
+
+Unlike TreeCCA, GAMCCA has no optional dependency (it is built entirely on
+scikit-learn's SplineTransformer/Ridge, already required by cca_zoo), so
+these tests run unconditionally.
+"""
 
 from __future__ import annotations
 
 import numpy as np
 import pytest
+from sklearn.preprocessing import SplineTransformer
 
 from cca_zoo.gam import GAMCCA
 
@@ -202,6 +208,19 @@ def test_encoders_attribute_shape(two_views_small: list[np.ndarray]) -> None:
         assert enc.predict().shape == (two_views_small[0].shape[0], k)
 
 
+def test_encoder_basis_is_sklearn_spline_transformer(
+    two_views_small: list[np.ndarray],
+) -> None:
+    """The per-view spline basis is an actual fitted SplineTransformer.
+
+    Confirms basis construction is delegated to scikit-learn rather than
+    reimplemented.
+    """
+    model = _make_model().fit(two_views_small)
+    for enc in model.encoders_:
+        assert isinstance(enc._spline, SplineTransformer)
+
+
 # ---------------------------------------------------------------------------
 # shape_function
 # ---------------------------------------------------------------------------
@@ -274,11 +293,15 @@ def test_gamcca_outperforms_linear_and_tree_on_smooth_nonmonotonic_data() -> Non
     linear combination of view 1's raw features can align with view 2 (so
     ``rCCA`` is expected to fail), while a per-view nonlinear encoder that
     (approximately) learns the "square" transform recovers near-perfect
-    cross-view correlation. GAMCCA's cubic-spline basis represents an exact
-    quadratic directly, so it should reach a given held-out correlation in
-    far fewer boosting rounds than TreeCCA's step-function tree ensembles,
-    and should out-generalise TreeCCA even at a matched round budget.
+    cross-view correlation. GAMCCA's B-spline basis represents a quadratic
+    almost exactly, so it should reach a given held-out correlation in far
+    fewer boosting rounds than TreeCCA's step-function tree ensembles, and
+    should out-generalise TreeCCA even at a matched round budget.
+
+    Marked slow since it also requires TreeCCA's optional ``xgboost``
+    dependency, not part of the base ``dev`` install.
     """
+    pytest.importorskip("xgboost", reason="xgboost is not installed")
     from cca_zoo.linear import rCCA
     from cca_zoo.tree import TreeCCA
 

--- a/tests/gam/test_gamcca.py
+++ b/tests/gam/test_gamcca.py
@@ -1,0 +1,316 @@
+"""Tests for GAMCCA."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cca_zoo.gam import GAMCCA
+
+
+def _make_model(latent_dimensions: int = 1, **kwargs: object) -> GAMCCA:
+    kwargs.setdefault("n_estimators", 10)
+    return GAMCCA(latent_dimensions=latent_dimensions, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# fit completes
+# ---------------------------------------------------------------------------
+
+
+def test_two_view_fit_completes(two_views_small: list[np.ndarray]) -> None:
+    """Fit completes on two-view data without error."""
+    model = _make_model()
+    fitted = model.fit(two_views_small)
+    assert fitted is model
+
+
+def test_three_view_fit_completes(three_views_small: list[np.ndarray]) -> None:
+    """Fit completes on three-view data without error."""
+    model = _make_model()
+    fitted = model.fit(three_views_small)
+    assert fitted is model
+    assert len(model.encoders_) == 3
+
+
+# ---------------------------------------------------------------------------
+# transform output shapes
+# ---------------------------------------------------------------------------
+
+
+def test_transform_shapes_training_data(two_views_small: list[np.ndarray]) -> None:
+    """Transform on training data returns (n_samples, latent_dimensions) arrays."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    result = model.transform(two_views_small)
+    assert len(result) == 2
+    n = two_views_small[0].shape[0]
+    for arr in result:
+        assert arr.shape == (n, k)
+
+
+def test_transform_on_test_data(two_views_small: list[np.ndarray]) -> None:
+    """Transform returns correct shapes for new (unseen) test samples."""
+    rng = np.random.default_rng(99)
+    test_views = [rng.standard_normal((10, 5)), rng.standard_normal((10, 5))]
+    k = 1
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    result = model.transform(test_views)
+    assert len(result) == 2
+    for arr in result:
+        assert arr.shape == (10, k)
+
+
+def test_transform_shapes_three_views(three_views_small: list[np.ndarray]) -> None:
+    """Transform on three-view data returns one array per view."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(three_views_small)
+    result = model.transform(three_views_small)
+    assert len(result) == 3
+    n = three_views_small[0].shape[0]
+    for arr in result:
+        assert arr.shape == (n, k)
+
+
+# ---------------------------------------------------------------------------
+# fit_transform consistency
+# ---------------------------------------------------------------------------
+
+
+def test_fit_transform_consistency(two_views_small: list[np.ndarray]) -> None:
+    """fit_transform equals fit().transform() numerically."""
+    m1 = _make_model()
+    m2 = _make_model()
+    result_ft = m1.fit_transform(two_views_small)
+    result_sep = m2.fit(two_views_small).transform(two_views_small)
+    for a, b in zip(result_ft, result_sep):
+        np.testing.assert_allclose(a, b, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# score shape and range
+# ---------------------------------------------------------------------------
+
+
+def test_score_shape(two_views_small: list[np.ndarray]) -> None:
+    """Score returns array of shape (latent_dimensions,)."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    s = model.score(two_views_small)
+    assert s.shape == (k,)
+
+
+def test_score_values_in_range(two_views_small: list[np.ndarray]) -> None:
+    """Score values lie in [-1, 1]."""
+    model = _make_model().fit(two_views_small)
+    s = model.score(two_views_small)
+    assert np.all(s >= -1.0 - 1e-9)
+    assert np.all(s <= 1.0 + 1e-9)
+
+
+# get_params/set_params roundtrip behaviour is exercised generically for
+# every model in the package (including GAMCCA) by
+# tests/test_sklearn_compat.py.
+
+
+# ---------------------------------------------------------------------------
+# weights is not implemented
+# ---------------------------------------------------------------------------
+
+
+def test_weights_not_fitted_raises() -> None:
+    """Accessing weights before fitting raises NotFittedError."""
+    from sklearn.exceptions import NotFittedError
+
+    model = GAMCCA()
+    with pytest.raises(NotFittedError):
+        _ = model.weights
+
+
+def test_weights_raises_not_implemented(two_views_small: list[np.ndarray]) -> None:
+    """Accessing weights after fitting raises NotImplementedError."""
+    model = _make_model().fit(two_views_small)
+    with pytest.raises(NotImplementedError, match="shape_function"):
+        _ = model.weights
+
+
+# ---------------------------------------------------------------------------
+# get_factor_loadings shapes
+# ---------------------------------------------------------------------------
+
+
+def test_get_factor_loadings_shapes(two_views_small: list[np.ndarray]) -> None:
+    """get_factor_loadings returns (n_features_i, k) arrays."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    loadings = model.get_factor_loadings(two_views_small)
+    assert len(loadings) == 2
+    for loading, view in zip(loadings, two_views_small):
+        assert loading.shape == (view.shape[1], k)
+
+
+# ---------------------------------------------------------------------------
+# pairwise_correlations shape
+# ---------------------------------------------------------------------------
+
+
+def test_pairwise_correlations_shape(two_views_small: list[np.ndarray]) -> None:
+    """pairwise_correlations returns (n_views, n_views, k)."""
+    k = 1
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    corrs = model.pairwise_correlations(two_views_small)
+    assert corrs.shape == (2, 2, k)
+
+
+# ---------------------------------------------------------------------------
+# center=False
+# ---------------------------------------------------------------------------
+
+
+def test_center_false(two_views_small: list[np.ndarray]) -> None:
+    """GAMCCA works with center=False."""
+    model = _make_model(center=False)
+    model.fit(two_views_small)
+    result = model.transform(two_views_small)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# gauss_seidel toggle
+# ---------------------------------------------------------------------------
+
+
+def test_jacobi_variant_fit_completes(two_views_small: list[np.ndarray]) -> None:
+    """Fit completes with gauss_seidel=False (Jacobi updates)."""
+    model = _make_model(gauss_seidel=False).fit(two_views_small)
+    result = model.transform(two_views_small)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# encoders_ attribute
+# ---------------------------------------------------------------------------
+
+
+def test_encoders_attribute_shape(two_views_small: list[np.ndarray]) -> None:
+    """encoders_ has one encoder per view, each producing k-dim output."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    assert len(model.encoders_) == 2
+    for enc in model.encoders_:
+        assert enc.k == k
+        assert enc.predict().shape == (two_views_small[0].shape[0], k)
+
+
+# ---------------------------------------------------------------------------
+# shape_function
+# ---------------------------------------------------------------------------
+
+
+def test_shape_function_shape(two_views_small: list[np.ndarray]) -> None:
+    """shape_function evaluates one feature's additive term at given points."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    x_grid = np.linspace(-2, 2, 7)
+    term = model.shape_function(view=0, feature=1, x=x_grid)
+    assert term.shape == (7, k)
+
+
+def test_shape_function_sums_to_prediction(two_views_small: list[np.ndarray]) -> None:
+    """Summed shape_function terms reproduce the encoder's raw prediction.
+
+    Summing every feature's shape_function at the training values should
+    reproduce the encoder's raw (base-margin-free) training prediction.
+    """
+    model = _make_model(latent_dimensions=1).fit(two_views_small)
+    view = two_views_small[0]
+    total = sum(model.shape_function(0, j, view[:, j]) for j in range(view.shape[1]))
+    np.testing.assert_allclose(total, model.encoders_[0].predict(), atol=1e-6)
+
+
+def test_shape_function_not_fitted_raises() -> None:
+    """Calling shape_function before fitting raises NotFittedError."""
+    from sklearn.exceptions import NotFittedError
+
+    model = GAMCCA()
+    with pytest.raises(NotFittedError):
+        model.shape_function(0, 0, np.array([0.0]))
+
+
+# ---------------------------------------------------------------------------
+# Correctness / optimality
+# ---------------------------------------------------------------------------
+
+
+def test_gamcca_finds_correlation_on_correlated_views(
+    correlated_views: list[np.ndarray],
+) -> None:
+    """GAMCCA finds substantial correlation on views with shared latent structure."""
+    model = GAMCCA(latent_dimensions=1, n_estimators=100, random_state=0)
+    s = model.fit(correlated_views).score(correlated_views)
+    assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
+
+
+def test_gamcca_finds_correlation_on_three_correlated_views() -> None:
+    """GAMCCA (multiview) finds substantial correlation on 3 correlated views."""
+    rng = np.random.default_rng(0)
+    z = rng.standard_normal((200, 1))
+    views = [
+        z @ rng.standard_normal((1, 5)) + 0.1 * rng.standard_normal((200, 5))
+        for _ in range(3)
+    ]
+    model = GAMCCA(latent_dimensions=1, n_estimators=150, random_state=0)
+    s = model.fit(views).score(views)
+    assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
+
+
+@pytest.mark.slow
+def test_gamcca_outperforms_linear_and_tree_on_smooth_nonmonotonic_data() -> None:
+    """GAMCCA beats rCCA and TreeCCA on a held-out, smooth-but-nonlinear task.
+
+    View 1 is a noisy linear copy of a shared latent factor ``z``; view 2 is
+    a noisy linear copy of ``z ** 2`` — a smooth but *non-monotonic* (even)
+    transform, chosen so that ``corr(z, z**2) ~ 0`` for symmetric ``z``.  No
+    linear combination of view 1's raw features can align with view 2 (so
+    ``rCCA`` is expected to fail), while a per-view nonlinear encoder that
+    (approximately) learns the "square" transform recovers near-perfect
+    cross-view correlation. GAMCCA's cubic-spline basis represents an exact
+    quadratic directly, so it should reach a given held-out correlation in
+    far fewer boosting rounds than TreeCCA's step-function tree ensembles,
+    and should out-generalise TreeCCA even at a matched round budget.
+    """
+    from cca_zoo.linear import rCCA
+    from cca_zoo.tree import TreeCCA
+
+    rng = np.random.default_rng(0)
+    n_train, n_test, p, noise = 500, 500, 5, 0.3
+    n = n_train + n_test
+    z = rng.standard_normal(n)
+    X1 = np.column_stack([z + noise * rng.standard_normal(n) for _ in range(p)])
+    X2 = np.column_stack([z**2 + noise * rng.standard_normal(n) for _ in range(p)])
+    X1_tr, X1_te = X1[:n_train], X1[n_train:]
+    X2_tr, X2_te = X2[:n_train], X2[n_train:]
+
+    n_estimators = 150
+
+    gam = GAMCCA(latent_dimensions=1, n_estimators=n_estimators, random_state=0)
+    gam_test = gam.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
+
+    tree = TreeCCA(
+        latent_dimensions=1, n_estimators=n_estimators, max_depth=5, random_state=0
+    )
+    tree_test = tree.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
+
+    rcca = rCCA(latent_dimensions=1, c=[0.3, 0.3])
+    rcca_test = rcca.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
+
+    assert gam_test > 0.9, (
+        f"Expected GAMCCA to recover the relationship, got {gam_test}"
+    )
+    assert gam_test > tree_test + 0.2, (
+        f"Expected GAMCCA ({gam_test}) to clearly beat TreeCCA ({tree_test}) "
+        f"at a matched budget of {n_estimators} boosting rounds"
+    )
+    assert gam_test > rcca_test + 0.5, (
+        f"Expected GAMCCA ({gam_test}) to clearly beat linear rCCA ({rcca_test})"
+    )

--- a/tests/gp/test_gpcca.py
+++ b/tests/gp/test_gpcca.py
@@ -1,0 +1,317 @@
+"""Tests for GPCCA.
+
+Like GAMCCA, GPCCA has no optional dependency (it is built entirely on
+scikit-learn's GaussianProcessRegressor, already required by cca_zoo), so
+these tests run unconditionally.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.gaussian_process import GaussianProcessRegressor
+
+from cca_zoo.gp import GPCCA
+
+
+def _make_model(latent_dimensions: int = 1, **kwargs: object) -> GPCCA:
+    return GPCCA(latent_dimensions=latent_dimensions, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# fit completes
+# ---------------------------------------------------------------------------
+
+
+def test_two_view_fit_completes(two_views_small: list[np.ndarray]) -> None:
+    """Fit completes on two-view data without error."""
+    model = _make_model()
+    fitted = model.fit(two_views_small)
+    assert fitted is model
+
+
+def test_three_view_fit_completes(three_views_small: list[np.ndarray]) -> None:
+    """Fit completes on three-view data without error."""
+    model = _make_model()
+    fitted = model.fit(three_views_small)
+    assert fitted is model
+    assert len(model.encoders_) == 3
+
+
+# ---------------------------------------------------------------------------
+# transform output shapes
+# ---------------------------------------------------------------------------
+
+
+def test_transform_shapes_training_data(two_views_small: list[np.ndarray]) -> None:
+    """Transform on training data returns (n_samples, latent_dimensions) arrays."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    result = model.transform(two_views_small)
+    assert len(result) == 2
+    n = two_views_small[0].shape[0]
+    for arr in result:
+        assert arr.shape == (n, k)
+
+
+def test_transform_on_test_data(two_views_small: list[np.ndarray]) -> None:
+    """Transform returns correct shapes for new (unseen) test samples."""
+    rng = np.random.default_rng(99)
+    test_views = [rng.standard_normal((10, 5)), rng.standard_normal((10, 5))]
+    k = 1
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    result = model.transform(test_views)
+    assert len(result) == 2
+    for arr in result:
+        assert arr.shape == (10, k)
+
+
+def test_transform_shapes_three_views(three_views_small: list[np.ndarray]) -> None:
+    """Transform on three-view data returns one array per view."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(three_views_small)
+    result = model.transform(three_views_small)
+    assert len(result) == 3
+    n = three_views_small[0].shape[0]
+    for arr in result:
+        assert arr.shape == (n, k)
+
+
+# ---------------------------------------------------------------------------
+# return_std uncertainty output
+# ---------------------------------------------------------------------------
+
+
+def test_transform_return_std_shapes_and_positive(
+    two_views_small: list[np.ndarray],
+) -> None:
+    """transform(..., return_std=True) returns matching-shape, positive stds."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    means, stds = model.transform(two_views_small, return_std=True)
+    n = two_views_small[0].shape[0]
+    assert len(means) == 2
+    assert len(stds) == 2
+    for mean, std in zip(means, stds):
+        assert mean.shape == (n, k)
+        assert std.shape == (n, k)
+        assert np.all(std > 0)
+
+
+# ---------------------------------------------------------------------------
+# fit_transform consistency
+# ---------------------------------------------------------------------------
+
+
+def test_fit_transform_consistency(two_views_small: list[np.ndarray]) -> None:
+    """fit_transform equals fit().transform() numerically."""
+    m1 = _make_model()
+    m2 = _make_model()
+    result_ft = m1.fit_transform(two_views_small)
+    result_sep = m2.fit(two_views_small).transform(two_views_small)
+    for a, b in zip(result_ft, result_sep):
+        np.testing.assert_allclose(a, b, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# score shape and range
+# ---------------------------------------------------------------------------
+
+
+def test_score_shape(two_views_small: list[np.ndarray]) -> None:
+    """Score returns array of shape (latent_dimensions,)."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    s = model.score(two_views_small)
+    assert s.shape == (k,)
+
+
+def test_score_values_in_range(two_views_small: list[np.ndarray]) -> None:
+    """Score values lie in [-1, 1]."""
+    model = _make_model().fit(two_views_small)
+    s = model.score(two_views_small)
+    assert np.all(s >= -1.0 - 1e-9)
+    assert np.all(s <= 1.0 + 1e-9)
+
+
+# get_params/set_params roundtrip behaviour is exercised generically for
+# every model in the package (including GPCCA) by
+# tests/test_sklearn_compat.py.
+
+
+# ---------------------------------------------------------------------------
+# weights is not implemented
+# ---------------------------------------------------------------------------
+
+
+def test_weights_not_fitted_raises() -> None:
+    """Accessing weights before fitting raises NotFittedError."""
+    from sklearn.exceptions import NotFittedError
+
+    model = GPCCA()
+    with pytest.raises(NotFittedError):
+        _ = model.weights
+
+
+def test_weights_raises_not_implemented(two_views_small: list[np.ndarray]) -> None:
+    """Accessing weights after fitting raises NotImplementedError."""
+    model = _make_model().fit(two_views_small)
+    with pytest.raises(NotImplementedError, match="Gaussian process"):
+        _ = model.weights
+
+
+# ---------------------------------------------------------------------------
+# get_factor_loadings shapes
+# ---------------------------------------------------------------------------
+
+
+def test_get_factor_loadings_shapes(two_views_small: list[np.ndarray]) -> None:
+    """get_factor_loadings returns (n_features_i, k) arrays."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    loadings = model.get_factor_loadings(two_views_small)
+    assert len(loadings) == 2
+    for loading, view in zip(loadings, two_views_small):
+        assert loading.shape == (view.shape[1], k)
+
+
+# ---------------------------------------------------------------------------
+# pairwise_correlations shape
+# ---------------------------------------------------------------------------
+
+
+def test_pairwise_correlations_shape(two_views_small: list[np.ndarray]) -> None:
+    """pairwise_correlations returns (n_views, n_views, k)."""
+    k = 1
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    corrs = model.pairwise_correlations(two_views_small)
+    assert corrs.shape == (2, 2, k)
+
+
+# ---------------------------------------------------------------------------
+# center=False
+# ---------------------------------------------------------------------------
+
+
+def test_center_false(two_views_small: list[np.ndarray]) -> None:
+    """GPCCA works with center=False."""
+    model = _make_model(center=False)
+    model.fit(two_views_small)
+    result = model.transform(two_views_small)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# encoders_ attribute
+# ---------------------------------------------------------------------------
+
+
+def test_encoders_attribute_shape(two_views_small: list[np.ndarray]) -> None:
+    """encoders_ has one encoder per view, each producing k-dim output."""
+    k = 2
+    model = _make_model(latent_dimensions=k).fit(two_views_small)
+    assert len(model.encoders_) == 2
+    for enc in model.encoders_:
+        assert enc.k == k
+        assert enc.predict().shape == (two_views_small[0].shape[0], k)
+
+
+def test_encoder_models_are_sklearn_gaussian_process_regressor(
+    two_views_small: list[np.ndarray],
+) -> None:
+    """Each fitted per-component model is an actual GaussianProcessRegressor.
+
+    Confirms the GP fit is delegated to scikit-learn rather than
+    reimplemented.
+    """
+    model = _make_model().fit(two_views_small)
+    for enc in model.encoders_:
+        for m in enc.models_:
+            assert isinstance(m, GaussianProcessRegressor)
+
+
+# ---------------------------------------------------------------------------
+# Correctness / optimality
+# ---------------------------------------------------------------------------
+
+
+def test_gpcca_finds_correlation_on_correlated_views(
+    correlated_views: list[np.ndarray],
+) -> None:
+    """GPCCA finds substantial correlation on views with shared latent structure."""
+    model = GPCCA(latent_dimensions=1, random_state=0)
+    s = model.fit(correlated_views).score(correlated_views)
+    assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
+
+
+def test_gpcca_finds_correlation_on_three_correlated_views() -> None:
+    """GPCCA (multiview) finds substantial correlation on 3 correlated views."""
+    rng = np.random.default_rng(0)
+    z = rng.standard_normal((200, 1))
+    views = [
+        z @ rng.standard_normal((1, 5)) + 0.1 * rng.standard_normal((200, 5))
+        for _ in range(3)
+    ]
+    model = GPCCA(latent_dimensions=1, random_state=0)
+    s = model.fit(views).score(views)
+    assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
+
+
+@pytest.mark.slow
+def test_gpcca_outperforms_others_on_genuine_interaction() -> None:
+    """GPCCA beats GAMCCA, TreeCCA, and rCCA on a genuine feature-interaction task.
+
+    View 1 is two noisy independent factors ``u, v``; view 2 is a noisy
+    copy of their *interaction* ``u * v`` -- not additively separable into
+    a function of ``u`` plus a function of ``v``. GAMCCA's additive-spline
+    encoder structurally cannot represent this; ``TreeCCA`` can only
+    approximate it via multivariate splits, and at its default
+    ``colsample_bytree`` a single tree is often starved of joint access to
+    both features. GPCCA's joint (non-additive) RBF kernel represents the
+    interaction directly.
+
+    Marked slow since it also requires TreeCCA's optional ``xgboost``
+    dependency, not part of the base ``dev`` install.
+    """
+    pytest.importorskip("xgboost", reason="xgboost is not installed")
+    from cca_zoo.gam import GAMCCA
+    from cca_zoo.linear import rCCA
+    from cca_zoo.tree import TreeCCA
+
+    rng = np.random.default_rng(0)
+    n_train, n_test, noise = 300, 300, 0.2
+    n = n_train + n_test
+    u = rng.standard_normal(n)
+    v = rng.standard_normal(n)
+    interaction = u * v
+    X1 = np.column_stack([u, v]) + noise * rng.standard_normal((n, 2))
+    X2 = np.column_stack([interaction, interaction]) + noise * rng.standard_normal(
+        (n, 2)
+    )
+    X1_tr, X1_te = X1[:n_train], X1[n_train:]
+    X2_tr, X2_te = X2[:n_train], X2[n_train:]
+
+    gp = GPCCA(latent_dimensions=1, random_state=0)
+    gp_test = gp.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
+
+    gam = GAMCCA(latent_dimensions=1, random_state=0)
+    gam_test = gam.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
+
+    tree = TreeCCA(latent_dimensions=1, n_estimators=150, max_depth=5, random_state=0)
+    tree_test = tree.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
+
+    rcca = rCCA(latent_dimensions=1, c=[0.3, 0.3])
+    rcca_test = rcca.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
+
+    assert gp_test > 0.7, f"Expected GPCCA to recover the interaction, got {gp_test}"
+    assert gp_test > gam_test + 0.05, (
+        f"Expected GPCCA ({gp_test}) to beat additive GAMCCA ({gam_test}) "
+        f"on a genuine feature interaction"
+    )
+    assert gp_test > tree_test + 0.05, (
+        f"Expected GPCCA ({gp_test}) to beat TreeCCA ({tree_test}) at "
+        f"TreeCCA's default colsample_bytree"
+    )
+    assert gp_test > rcca_test + 0.3, (
+        f"Expected GPCCA ({gp_test}) to clearly beat linear rCCA ({rcca_test})"
+    )

--- a/tests/gp/test_gpcca.py
+++ b/tests/gp/test_gpcca.py
@@ -12,6 +12,7 @@ import pytest
 from sklearn.gaussian_process import GaussianProcessRegressor
 
 from cca_zoo.gp import GPCCA
+from cca_zoo.gp._gpcca import _GpEncoder, _SparseGpEncoder
 
 
 def _make_model(latent_dimensions: int = 1, **kwargs: object) -> GPCCA:
@@ -255,6 +256,84 @@ def test_gpcca_finds_correlation_on_three_correlated_views() -> None:
     model = GPCCA(latent_dimensions=1, random_state=0)
     s = model.fit(views).score(views)
     assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
+
+
+# ---------------------------------------------------------------------------
+# sparse (inducing-point) approximation
+# ---------------------------------------------------------------------------
+
+
+def test_sparse_fit_completes_and_shapes(two_views_small: list[np.ndarray]) -> None:
+    """n_inducing < n_samples switches to the sparse DTC encoder and fits."""
+    k = 2
+    n = two_views_small[0].shape[0]
+    model = _make_model(latent_dimensions=k, n_inducing=n // 2).fit(two_views_small)
+    for enc in model.encoders_:
+        assert isinstance(enc, _SparseGpEncoder)
+    result = model.transform(two_views_small)
+    assert len(result) == 2
+    for arr in result:
+        assert arr.shape == (n, k)
+
+
+def test_sparse_return_std_shapes_and_positive(
+    two_views_small: list[np.ndarray],
+) -> None:
+    """Sparse transform(..., return_std=True) returns positive, matching-shape stds."""
+    k = 2
+    n = two_views_small[0].shape[0]
+    model = _make_model(latent_dimensions=k, n_inducing=n // 2).fit(two_views_small)
+    means, stds = model.transform(two_views_small, return_std=True)
+    for mean, std in zip(means, stds):
+        assert mean.shape == (n, k)
+        assert std.shape == (n, k)
+        assert np.all(std > 0)
+
+
+def test_n_inducing_at_least_n_samples_falls_back_to_exact(
+    two_views_small: list[np.ndarray],
+) -> None:
+    """n_inducing >= n_samples is equivalent to exact (dense) GP inference."""
+    n = two_views_small[0].shape[0]
+    model = _make_model(n_inducing=10 * n).fit(two_views_small)
+    for enc in model.encoders_:
+        assert isinstance(enc, _GpEncoder)
+        assert not isinstance(enc, _SparseGpEncoder)
+
+
+def test_sparse_finds_correlation_on_correlated_views(
+    correlated_views: list[np.ndarray],
+) -> None:
+    """The sparse approximation still recovers substantial correlation."""
+    n = correlated_views[0].shape[0]
+    model = GPCCA(latent_dimensions=1, random_state=0, n_inducing=max(10, n // 3))
+    s = model.fit(correlated_views).score(correlated_views)
+    assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
+
+
+@pytest.mark.slow
+def test_sparse_scales_to_large_sample_sizes() -> None:
+    """Sparse GPCCA fits at a sample size that would defeat exact GP inference.
+
+    Exact GP inference redoes an O(n^3) Cholesky factorisation at every
+    Newton step of every inner/outer round, which would be impractically
+    slow here; the sparse approximation should still recover the
+    underlying correlation.
+    """
+    rng = np.random.default_rng(0)
+    n_train, n_test, noise = 4000, 500, 0.3
+    n = n_train + n_test
+    z = rng.standard_normal(n)
+    X1 = np.column_stack([z + noise * rng.standard_normal(n) for _ in range(3)])
+    X2 = np.column_stack([z**2 + noise * rng.standard_normal(n) for _ in range(3)])
+    X1_tr, X1_te = X1[:n_train], X1[n_train:]
+    X2_tr, X2_te = X2[:n_train], X2[n_train:]
+
+    model = GPCCA(latent_dimensions=1, random_state=0, n_inducing=100)
+    test_corr = model.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
+    assert test_corr > 0.7, (
+        f"Expected substantial held-out correlation, got {test_corr}"
+    )
 
 
 @pytest.mark.slow

--- a/tests/test_sklearn_compat.py
+++ b/tests/test_sklearn_compat.py
@@ -36,6 +36,7 @@ _MODULE_NAMES = [
     "cca_zoo.nonparametric",
     "cca_zoo.tree",
     "cca_zoo.gam",
+    "cca_zoo.gp",
     "cca_zoo.probabilistic",
 ]
 

--- a/tests/test_sklearn_compat.py
+++ b/tests/test_sklearn_compat.py
@@ -35,6 +35,7 @@ _MODULE_NAMES = [
     "cca_zoo.linear",
     "cca_zoo.nonparametric",
     "cca_zoo.tree",
+    "cca_zoo.gam",
     "cca_zoo.probabilistic",
 ]
 


### PR DESCRIPTION
## Summary

- Adds `cca_zoo.gam.GAMCCA`: nonlinear multiview CCA using a generalized additive model (one B-spline term per input feature) as the per-view encoder, trained on the shared Eckart-Young (EY) objective. Fit the way GAM software such as `mgcv` fits an ordinary GAM rather than by boosting: an inner P-IRLS loop takes Newton steps on the EY loss, wrapped in an outer loop that re-selects smoothing parameters via `RidgeCV`'s efficient leave-one-out cross-validation. Built entirely on scikit-learn's `SplineTransformer`/`Ridge`/`RidgeCV` — no new dependency.
- Adds `cca_zoo.gp.GPCCA`: nonlinear multiview CCA using a Gaussian process with a joint (non-additive) ARD-RBF kernel per view, also on the EY objective, using the same inner(fixed-kernel Newton)/outer(marginal-likelihood) recipe. Unlike GAMCCA's additive splines, the joint kernel represents genuine cross-feature interactions directly, and `transform(..., return_std=True)` exposes calibrated posterior uncertainty. Also built entirely on scikit-learn (`GaussianProcessRegressor`/`RBF`/`ConstantKernel`) — no new dependency.
- Adds a sparse (Deterministic Training Conditional) approximation to `GPCCA` via `n_inducing=...`, for datasets too large for exact GP inference's `O(n^3)` cost — reduces fitting to `O(n * n_inducing^2)` by conditioning on an inducing-point subset (selected via `sklearn.cluster.kmeans_plusplus`), while still using every training row for the actual working-response fit.
- Promotes `ey_diag_hessian` and `random_orthogonal_embedding` (previously private to individual models) into the shared `cca_zoo._utils._ey` module, used by `TreeCCA`, `GAMCCA`, and `GPCCA` alike.
- Registers both new modules throughout the package: `cca_zoo/__init__.py`, `tests/test_sklearn_compat.py`'s sklearn-estimator-contract checks, `mkdocs.yml` nav, `docs/user-guide/`, `docs/api/`, `README.md`, and `CHANGELOG.md`.

## Test plan

- [x] `pytest -q --no-cov` (full suite, fast + slow): 611 passed, 5 skipped (skips are pre-existing optional-dependency gaps — `torch`, `numpyro` — unrelated to this change)
- [x] `ruff format` / `ruff check`: clean on all new/touched files
- [x] `mypy`: clean on all new/touched files
- [x] `mkdocs build --strict`: clean
- [x] GAMCCA and GPCCA both verified to outperform `TreeCCA`/`rCCA` on their respective held-out benchmarks (smooth-nonmonotonic for GAMCCA; genuine feature interaction for GPCCA)
- [x] Sparse GPCCA verified to fit in well under a second at 4,000 training samples while recovering held-out correlation above 0.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T91RFTxCKGdLZicPpJhNMU

---
_Generated by [Claude Code](https://claude.ai/code/session_01T91RFTxCKGdLZicPpJhNMU)_