### PR TITLE
Add GitHub community health files and PR/issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jameschapman19

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Report an error or unexpected behaviour in CCA-Zoo
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproducible example
+      description: A short, self-contained code snippet that reproduces the issue.
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Full error output / traceback
+      render: shell
+
+  - type: input
+    id: version
+    attributes:
+      label: cca-zoo version
+      description: Output of `python -c "import cca_zoo; print(cca_zoo.__version__)"`
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Python version and OS
+      placeholder: e.g. Python 3.12, Ubuntu 22.04
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://jameschapman19.github.io/cca_zoo/
+    about: Check the docs and API reference before filing an issue.
+  - name: Existing issues
+    url: https://github.com/jameschapman19/cca_zoo/issues
+    about: Search open and closed issues to see if yours has already been reported.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest a new model, method, or enhancement for CCA-Zoo
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do that CCA-Zoo doesn't currently support?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        What would you like to see added? If this is a new model, include the paper
+        reference (title, authors, venue/year) it comes from.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you're currently using, or other approaches you considered.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What does this PR do, and why? Link any related issue (e.g. "Fixes #123"). -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New model / feature
+- [ ] Documentation
+- [ ] Refactor / internal change
+- [ ] Other (describe above)
+
+## Checklist
+
+- [ ] `uv run ruff check .` and `uv run ruff format --check .` pass
+- [ ] `uv run mypy cca_zoo` passes
+- [ ] `uv run pytest -m "not slow"` passes locally
+- [ ] Added or updated tests for all new/changed behaviour
+- [ ] Added/updated docstrings and, for new models, an entry in `docs/api/*.md`
+- [ ] Updated `CHANGELOG.md` if this is user-facing
+
+<!--
+Adding a new model? See docs/contributing.md#adding-a-new-model for the full
+checklist (BaseModel/BaseDeep inheritance, _parameter_constraints, exports,
+docs, tests).
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,69 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our
+standards of acceptable behavior and will take appropriate and fair
+corrective action in response to any behavior that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, pull
+requests, discussions, and any other project-related communication), and
+also applies when an individual is officially representing the community in
+public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers via a private message on GitHub
+([@jameschapman19](https://github.com/jameschapman19)). All complaints will
+be reviewed and investigated promptly and fairly.
+
+All maintainers are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/README.md
+++ b/README.md
@@ -182,4 +182,6 @@ If CCA-Zoo is useful in your research, please cite:
 
 ## Contributing
 
-Contributions are welcome. See [docs/contributing.md](docs/contributing.md) for development setup, coding standards, and pull request guidelines.
+Contributions are welcome. See [docs/contributing.md](docs/contributing.md) for development setup, coding standards, and pull request guidelines. Please also read our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Found a security issue? See [SECURITY.md](SECURITY.md) for how to report it privately.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+CCA-Zoo follows [semantic versioning](https://semver.org/). Only the latest
+release on PyPI is actively supported with security fixes; users are
+encouraged to stay up to date via `uv add --upgrade cca-zoo` / `pip install
+--upgrade cca-zoo`.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report it privately via
+[GitHub Security Advisories](https://github.com/jameschapman19/cca_zoo/security/advisories/new)
+for this repository. Include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce it (a minimal code sample where possible)
+- The affected version(s)
+
+You should receive an initial response within a few days. If the report is
+confirmed, we will work on a fix and coordinate disclosure timing with you
+before any public release.
+
+## Scope
+
+CCA-Zoo is a research library for canonical correlation analysis and related
+multiview methods; it is not designed to process untrusted input. As with
+any package that unpickles model objects or loads data from `numpy`/`torch`
+files, do not load model checkpoints or datasets from untrusted sources.


### PR DESCRIPTION
## Summary

- Add `.github/pull_request_template.md` with a checklist tied to the repo's actual CI gates (ruff, mypy, pytest, docs coverage)
- Add structured issue forms: `.github/ISSUE_TEMPLATE/bug_report.yml`, `feature_request.yml`, and `config.yml` (blank issues disabled, links to docs and existing issues)
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
- Add `SECURITY.md` documenting private vulnerability reporting via GitHub Security Advisories
- Add `.github/CODEOWNERS` routing review requests to @jameschapman19
- Link the Code of Conduct and Security policy from the README's Contributing section

Together with the existing `docs/contributing.md`, this fills out GitHub's community profile checklist and gives contributors clear structure for PRs and issues.

Not included: a root `CONTRIBUTING.md` (redundant — `docs/contributing.md` is already picked up by GitHub's community-profile detection) and a `CLAUDE.md` (the repo's `.gitignore` explicitly excludes it, which reads as a deliberate choice to keep it out of the public repo — happy to add one if you'd like that reversed).

## Type of change

- [ ] Bug fix
- [ ] New model / feature
- [x] Documentation
- [ ] Refactor / internal change
- [ ] Other (describe above)

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass (no Python changed)
- [x] `uv run mypy cca_zoo` passes (no Python changed)
- [x] `uv run pytest -m "not slow"` passes locally (no Python changed)
- [ ] Added or updated tests for all new/changed behaviour (n/a — non-code files)
- [ ] Added/updated docstrings and, for new models, an entry in `docs/api/*.md` (n/a)
- [ ] Updated `CHANGELOG.md` if this is user-facing (repo tooling change, not a package release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiusWuDHnKeBrzxvnurtty

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiusWuDHnKeBrzxvnurtty)_