### PR TITLE
Fix ruff docstring/format lint failures on main

### DIFF
--- a/cca_zoo/linear/_iterative.py
+++ b/cca_zoo/linear/_iterative.py
@@ -230,8 +230,7 @@ class PLS_ALS(_BaseIterative):
 
 
 def _bisect_threshold(x: np.ndarray, l1_bound: float) -> np.ndarray:
-    """Find the soft threshold that makes the L2-normalised thresholded
-    vector's L1 norm equal ``l1_bound``.
+    r"""Find the soft threshold hitting ``l1_bound`` L1 norm after L2-normalising.
 
     ``l1_bound`` (``tau * sqrt(p)``, see :class:`SCCA_PMD`) is only a
     meaningful constraint on a *unit-L2-norm* vector: ``||w||_1 <= sqrt(p)``
@@ -245,7 +244,7 @@ def _bisect_threshold(x: np.ndarray, l1_bound: float) -> np.ndarray:
     whereas the raw L1 norm is not. ``x`` here is an un-normalised
     power-iteration update whose scale depends on the data
     (:meth:`SCCA_PMD._update_weight` passes ``views[i].T @ target``,
-    typically :math:`O(\\sqrt{n})` in magnitude for standardised data),
+    typically :math:`O(\sqrt{n})` in magnitude for standardised data),
     not on ``tau``, so comparing that raw L1 norm directly against
     ``l1_bound`` made the constraint's effective strength depend on the
     data's scale rather than only on ``tau`` -- in the regime where the

--- a/docs/user-guide/gp.md
+++ b/docs/user-guide/gp.md
@@ -96,7 +96,9 @@ function of the $(n, m)$ and $(m, m)$ inducing-covariance matrices instead of th
 one, costing $O(n \, m^2 + m^3)$ instead of $O(n^3)$:
 
 ```python
-model = GPCCA(latent_dimensions=1, n_inducing=200).fit([X1, X2])  # X1, X2 have many samples
+model = GPCCA(latent_dimensions=1, n_inducing=200).fit(
+    [X1, X2]
+)  # X1, X2 have many samples
 ```
 
 Kernel hyperparameters are still selected by an *exact* marginal-likelihood fit — just on the

--- a/tests/linear/test_iterative.py
+++ b/tests/linear/test_iterative.py
@@ -189,8 +189,9 @@ def test_scca_pmd_achieves_sparsity(two_views: list[np.ndarray]) -> None:
 
 
 def test_scca_pmd_invariant_to_input_scale(two_views: list[np.ndarray]) -> None:
-    """SCCA_PMD's fitted weights (up to sign) must not depend on the
-    overall scale of the input data -- tau is the only sparsity control.
+    """SCCA_PMD's fitted weights (up to sign) must not depend on input scale.
+
+    tau is the only sparsity control.
 
     Regression test: _bisect_threshold used to compare the *unnormalised*
     power-iteration update's L1 norm directly against l1_bound (a bound
@@ -216,10 +217,12 @@ def test_scca_pmd_invariant_to_input_scale(two_views: list[np.ndarray]) -> None:
 def test_scca_pmd_tau_controls_sparsity_monotonically(
     two_views: list[np.ndarray],
 ) -> None:
-    """Increasing tau must not decrease the number of selected features:
+    """Increasing tau must not decrease the number of selected features.
+
     tau=1 bounds by the Cauchy-Schwarz maximum for a unit vector, so it
     should recover the (denser) unconstrained solution, not one sparser
-    than a smaller tau's."""
+    than a smaller tau's.
+    """
     taus = [0.3, 0.5, 0.7, 1.0]
     nnz_by_tau = []
     for tau in taus:


### PR DESCRIPTION
## Summary

- `Lint (ruff)` has been red on `main` since #236 merged. Two docstrings — one in `cca_zoo/linear/_iterative.py`, one in `tests/linear/test_iterative.py` — violated `D205` (blank line required after summary) and `D301` (needs `r"""` prefix for a docstring containing a backslash escape), and a third in the same test file violated `D209` (closing quotes on their own line).
- Fixing `ruff check` unmasked a pre-existing `ruff format --check` violation in `docs/user-guide/gp.md` (that step was being skipped in CI because the `ruff check` step failed first) — reformatted via `uv run ruff format .`.
- No behavior change: docstring wording/wrapping and one markdown code sample's line wrap only.

## Type of change

- [ ] Bug fix
- [ ] New model / feature
- [ ] Documentation
- [x] Refactor / internal change
- [ ] Other (describe above)

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy cca_zoo` passes
- [x] `uv run pytest -m "not slow"` passes locally (109/109 in the affected module, full fast suite green)
- [ ] Added or updated tests for all new/changed behaviour (n/a — no behavior change)
- [ ] Added/updated docstrings and, for new models, an entry in `docs/api/*.md` (n/a)
- [ ] Updated `CHANGELOG.md` if this is user-facing (n/a — internal lint fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiusWuDHnKeBrzxvnurtty

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiusWuDHnKeBrzxvnurtty)_