### PR TITLE
Drop underscores from algorithm-suffix class names; rename GPCCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,16 +62,27 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Renamed `CCA_EY` -> `CCAEY`, `MCCA_EY` -> `MCCAEY`, `PLS_EY` -> `PLSEY`, `DCCA_EY` -> `DCCAEY`,
-  and `SCCA_Span` -> `SCCASpan` to drop the underscore, matching sklearn's own class-naming
-  convention (`RidgeCV`, `SGDRegressor`, never `Ridge_CV`). The old underscored names still work
-  but now emit a `FutureWarning` (via `sklearn.utils.deprecated`) and will be removed in a future
-  release. `SCCA_PMD`, `SCCA_ADMM`, `SCCA_IPLS`, `DCCA_NOI`, `DCCA_SDL`, and `PLS_ALS` keep their
-  underscore deliberately: `EY` and `Span` are short enough (or already word-shaped) to read fine
-  concatenated onto their base name, but stacking `PMD`/`ADMM`/`IPLS`/`NOI`/`SDL`/`ALS` directly
-  onto `SCCA`/`DCCA`/`PLS` with no separator produces a run of 7-8 capital letters with no visual
-  seam at all (e.g. `SCCAADMM`) — worse than any real sklearn precedent, which never concatenates
-  two multi-letter all-caps acronyms with nothing letter-shaped between them.
+- Renamed every underscored algorithm-suffix class to drop the underscore, matching sklearn's own
+  class-naming convention (`RidgeCV`, `SGDRegressor`, never `Ridge_CV`), with no exceptions:
+  `CCA_EY` -> `CCAEY`, `MCCA_EY` -> `MCCAEY`, `PLS_EY` -> `PLSEY`, `DCCA_EY` -> `DCCAEY`,
+  `PLS_ALS` -> `PLSALS`, `SCCA_PMD` -> `SCCAPMD`, `SCCA_ADMM` -> `SCCAADMM`,
+  `SCCA_IPLS` -> `SCCAIPLS`, `SCCA_Span` -> `SCCASpan`, `DCCA_NOI` -> `DCCANOI`,
+  `DCCA_SDL` -> `DCCASDL`. The old underscored names still work but now emit a `FutureWarning`
+  (via `sklearn.utils.deprecated`) and will be removed in a future release. This only affects the
+  *algorithm*-suffix slot (how a model is fit, e.g. `SCCA` + `PMD`/`ADMM`/`IPLS`/`Span`); the
+  *architecture*-prefix slot (what a model is, e.g. `K`/`G`/`T`/`D`/`M`/`Tree` + `CCA`) is otherwise
+  untouched, since those already match the abbreviation each method's own literature uses (`DCCA`
+  for Deep CCA, `KCCA` for Kernel CCA, etc.) rather than being a naming-convention artifact that
+  could be tidied.
+- Renamed `GPCCA` -> `GaussianProcessCCA`, matching sklearn's own `GaussianProcessRegressor`/
+  `GaussianProcessClassifier` naming rather than abbreviating "Gaussian Process" to `GP` — unlike
+  `DCCA`/`KCCA`/`TCCA`/`GCCA`, `GPCCA` isn't an abbreviation inherited from an external paper (it's
+  new to this library), so there's no established literature form to preserve, and sklearn's own
+  precedent for this exact algorithm spells it out in full. `GAMCCA` and `TreeCCA` keep their
+  current names: `GAM` is a self-sufficient term of art in statistics the way `MLP`/`PLS`/`ARD` are
+  in sklearn (nobody spells out "Generalized Additive Model" as a model name), and `TreeCCA` is
+  already the name given in its own source paper. `GPCCA` still works but now emits a
+  `FutureWarning` and will be removed in a future release.
 - `CCA_EY` (and `MCCA_EY`, which inherits it) now initialises its weights
   differently from `PLS_EY`, matching each loss's own structure: `PLS_EY`
   keeps a plain, data-independent unit-norm-orthogonal-weight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,16 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Renamed `CCA_EY` -> `CCAEY`, `MCCA_EY` -> `MCCAEY`, `PLS_EY` -> `PLSEY`, `DCCA_EY` -> `DCCAEY`,
+  and `SCCA_Span` -> `SCCASpan` to drop the underscore, matching sklearn's own class-naming
+  convention (`RidgeCV`, `SGDRegressor`, never `Ridge_CV`). The old underscored names still work
+  but now emit a `FutureWarning` (via `sklearn.utils.deprecated`) and will be removed in a future
+  release. `SCCA_PMD`, `SCCA_ADMM`, `SCCA_IPLS`, `DCCA_NOI`, `DCCA_SDL`, and `PLS_ALS` keep their
+  underscore deliberately: `EY` and `Span` are short enough (or already word-shaped) to read fine
+  concatenated onto their base name, but stacking `PMD`/`ADMM`/`IPLS`/`NOI`/`SDL`/`ALS` directly
+  onto `SCCA`/`DCCA`/`PLS` with no separator produces a run of 7-8 capital letters with no visual
+  seam at all (e.g. `SCCAADMM`) — worse than any real sklearn precedent, which never concatenates
+  two multi-letter all-caps acronyms with nothing letter-shaped between them.
 - `CCA_EY` (and `MCCA_EY`, which inherits it) now initialises its weights
   differently from `PLS_EY`, matching each loss's own structure: `PLS_EY`
   keeps a plain, data-independent unit-norm-orthogonal-weight

--- a/cca_zoo/_utils/_ey.py
+++ b/cca_zoo/_utils/_ey.py
@@ -316,7 +316,7 @@ def ey_diag_hessian(
     Hessian's real signal through for high-leverage outliers.
 
     Used by both :class:`~cca_zoo.gam.GAMCCA` (as a ``Ridge``/``RidgeCV``
-    ``sample_weight``) and :class:`~cca_zoo.gp.GPCCA` (as a
+    ``sample_weight``) and :class:`~cca_zoo.gp.GaussianProcessCCA` (as a
     ``GaussianProcessRegressor`` per-sample ``alpha``, the heteroscedastic-
     noise parameter that plays the same "how much to trust this
     observation" role there).

--- a/cca_zoo/_utils/_ey.py
+++ b/cca_zoo/_utils/_ey.py
@@ -1,7 +1,7 @@
 r"""Shared machinery for the Eckart-Young (EY) unconstrained CCA objective.
 
-This is the loss used by :class:`~cca_zoo.linear.gradient.CCA_EY`,
-:class:`~cca_zoo.linear.gradient.MCCA_EY`, :class:`~cca_zoo.deep.DCCA_EY`, and
+This is the loss used by :class:`~cca_zoo.linear.gradient.CCAEY`,
+:class:`~cca_zoo.linear.gradient.MCCAEY`, :class:`~cca_zoo.deep.DCCAEY`, and
 :class:`~cca_zoo.tree.TreeCCA`: an unconstrained (no manifold projection
 required) stand-in for canonical correlation analysis that is a stationary
 point exactly at the canonical directions.
@@ -103,7 +103,7 @@ def random_orthonormal_weights(
     Each view's weight matrix is the $Q$ factor of a QR decomposition of
     an i.i.d. standard normal matrix, so $W_i^\top W_i = I$ exactly, before
     any gradient step and without looking at the data at all. This matches
-    the structure of :class:`~cca_zoo.linear.gradient.PLS_EY`'s own penalty,
+    the structure of :class:`~cca_zoo.linear.gradient.PLSEY`'s own penalty,
     which drives weights towards orthonormality directly in weight space
     (see :func:`weight_gram_mean`) — the loss's own fixed point is already
     the natural initial point's shape.
@@ -137,7 +137,7 @@ def cheap_orthonormal_projection_weights(
     Classical CCA whitens each view with a full $(p, p)$ eigendecomposition
     of its covariance before fitting; that full-batch pass is exactly what
     the EY reformulation exists to avoid (see
-    :class:`~cca_zoo.linear.gradient.CCA_EY`). This is a cheap substitute
+    :class:`~cca_zoo.linear.gradient.CCAEY`). This is a cheap substitute
     usable only at initialisation: draw random directions, project one
     mini-batch, and QR-orthonormalise the resulting $(n, k)$ projection
     instead of the $(p, p)$ data covariance, then pull that
@@ -153,7 +153,7 @@ def cheap_orthonormal_projection_weights(
     so the resulting projections are exactly orthonormal ($Q^\top Q = I$)
     on that mini-batch — a cheap stand-in for the reward term's ideal
     starting point ($V \approx I$; see :func:`ey_cross_covariance`) and
-    the natural match for :class:`~cca_zoo.linear.gradient.CCA_EY`'s own
+    the natural match for :class:`~cca_zoo.linear.gradient.CCAEY`'s own
     fixed point. This orthonormalises only the *first* mini-batch, though:
     every later step draws an independent fresh batch, so this does not,
     by itself, prevent the ``c=0`` divergence risk noted in that class's

--- a/cca_zoo/deep/__init__.py
+++ b/cca_zoo/deep/__init__.py
@@ -20,8 +20,10 @@ if _torch_available and _lightning_available:
     from cca_zoo.deep._dcca import DCCA
     from cca_zoo.deep._dcca_ey import DCCA_EY as DCCA_EY
     from cca_zoo.deep._dcca_ey import DCCAEY
-    from cca_zoo.deep._dcca_noi import DCCA_NOI
-    from cca_zoo.deep._dcca_sdl import DCCA_SDL
+    from cca_zoo.deep._dcca_noi import DCCA_NOI as DCCA_NOI
+    from cca_zoo.deep._dcca_noi import DCCANOI
+    from cca_zoo.deep._dcca_sdl import DCCA_SDL as DCCA_SDL
+    from cca_zoo.deep._dcca_sdl import DCCASDL
     from cca_zoo.deep._dccae import DCCAE
     from cca_zoo.deep._dgcca import DGCCA
     from cca_zoo.deep._dmcca import DMCCA
@@ -35,8 +37,8 @@ if _torch_available and _lightning_available:
         "BarlowTwins",
         "DCCA",
         "DCCAEY",
-        "DCCA_NOI",
-        "DCCA_SDL",
+        "DCCANOI",
+        "DCCASDL",
         "DCCAE",
         "DGCCA",
         "DMCCA",
@@ -47,7 +49,8 @@ if _torch_available and _lightning_available:
         "VICReg",
         "objectives",
     ]
-    # Deprecated alias DCCA_EY stays importable for backward compatibility
-    # but is intentionally left out of __all__/docs.
+    # Deprecated aliases DCCA_EY, DCCA_NOI, DCCA_SDL stay importable for
+    # backward compatibility but are intentionally left out of
+    # __all__/docs.
 else:
     __all__ = []

--- a/cca_zoo/deep/__init__.py
+++ b/cca_zoo/deep/__init__.py
@@ -18,7 +18,8 @@ if _torch_available and _lightning_available:
     from cca_zoo.deep._base import BaseDeep
     from cca_zoo.deep._data import MultiviewDataset
     from cca_zoo.deep._dcca import DCCA
-    from cca_zoo.deep._dcca_ey import DCCA_EY
+    from cca_zoo.deep._dcca_ey import DCCA_EY as DCCA_EY
+    from cca_zoo.deep._dcca_ey import DCCAEY
     from cca_zoo.deep._dcca_noi import DCCA_NOI
     from cca_zoo.deep._dcca_sdl import DCCA_SDL
     from cca_zoo.deep._dccae import DCCAE
@@ -33,7 +34,7 @@ if _torch_available and _lightning_available:
         "BaseDeep",
         "BarlowTwins",
         "DCCA",
-        "DCCA_EY",
+        "DCCAEY",
         "DCCA_NOI",
         "DCCA_SDL",
         "DCCAE",
@@ -46,5 +47,7 @@ if _torch_available and _lightning_available:
         "VICReg",
         "objectives",
     ]
+    # Deprecated alias DCCA_EY stays importable for backward compatibility
+    # but is intentionally left out of __all__/docs.
 else:
     __all__ = []

--- a/cca_zoo/deep/_dcca_ey.py
+++ b/cca_zoo/deep/_dcca_ey.py
@@ -1,8 +1,9 @@
-"""DCCA_EY — Deep CCA with EigenGame / Eckart-Young objective."""
+"""DCCAEY — Deep CCA with EigenGame / Eckart-Young objective."""
 
 from __future__ import annotations
 
 import torch
+from sklearn.utils import deprecated
 
 from cca_zoo.deep._dcca import DCCA
 
@@ -38,7 +39,7 @@ def _cca_cv(
     return c, v
 
 
-class DCCA_EY(DCCA):
+class DCCAEY(DCCA):
     r"""DCCA using the EigenGame / Eckart-Young (EY) objective.
 
     For $M$ views with embeddings $Z_1, \dots, Z_M$, define the
@@ -77,7 +78,7 @@ class DCCA_EY(DCCA):
         >>> import torch.nn as nn
         >>> enc1 = nn.Linear(10, 4)
         >>> enc2 = nn.Linear(8, 4)
-        >>> model = DCCA_EY(latent_dimensions=4, encoders=[enc1, enc2])
+        >>> model = DCCAEY(latent_dimensions=4, encoders=[enc1, enc2])
     """
 
     def loss(
@@ -109,3 +110,8 @@ class DCCA_EY(DCCA):
             "rewards": rewards,
             "penalties": penalties,
         }
+
+
+@deprecated("Renamed to DCCAEY for sklearn-style naming; use DCCAEY instead.")
+class DCCA_EY(DCCAEY):
+    pass

--- a/cca_zoo/deep/_dcca_noi.py
+++ b/cca_zoo/deep/_dcca_noi.py
@@ -1,9 +1,10 @@
-"""DCCA_NOI — Deep CCA via Non-linear Orthogonal Iterations (Wang 2015)."""
+"""DCCANOI — Deep CCA via Non-linear Orthogonal Iterations (Wang 2015)."""
 
 from __future__ import annotations
 
 import torch
 import torch.nn as nn
+from sklearn.utils import deprecated
 
 from cca_zoo.deep._dcca import DCCA
 from cca_zoo.deep.objectives import _inv_sqrtm
@@ -67,7 +68,7 @@ class _BatchWhiten(nn.Module):
         return x @ w
 
 
-class DCCA_NOI(DCCA):
+class DCCANOI(DCCA):
     r"""Deep CCA via Non-linear Orthogonal Iterations.
 
     Uses batch whitening to approximate the CCA whitening step
@@ -106,7 +107,7 @@ class DCCA_NOI(DCCA):
         >>> import torch.nn as nn
         >>> enc1 = nn.Linear(10, 4)
         >>> enc2 = nn.Linear(8, 4)
-        >>> model = DCCA_NOI(latent_dimensions=4, encoders=[enc1, enc2], rho=0.1)
+        >>> model = DCCANOI(latent_dimensions=4, encoders=[enc1, enc2], rho=0.1)
     """
 
     def __init__(
@@ -162,3 +163,8 @@ class DCCA_NOI(DCCA):
                 if i != j:
                     total = total + self.mse(representations[i], whitened[j].detach())
         return {"objective": total}
+
+
+@deprecated("Renamed to DCCANOI for sklearn-style naming; use DCCANOI instead.")
+class DCCA_NOI(DCCANOI):
+    pass

--- a/cca_zoo/deep/_dcca_sdl.py
+++ b/cca_zoo/deep/_dcca_sdl.py
@@ -1,10 +1,11 @@
-"""DCCA_SDL — Stochastic Decorrelation Loss (Chang 2018)."""
+"""DCCASDL — Stochastic Decorrelation Loss (Chang 2018)."""
 
 from __future__ import annotations
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from sklearn.utils import deprecated
 
 from cca_zoo.deep._dcca import DCCA
 
@@ -26,7 +27,7 @@ def _sdl_loss(view: torch.Tensor) -> torch.Tensor:
     return cov[mask].abs().mean()
 
 
-class DCCA_SDL(DCCA):
+class DCCASDL(DCCA):
     r"""Deep CCA via Stochastic Decorrelation Loss.
 
     Combines an MSE alignment loss between views with a within-view
@@ -60,7 +61,7 @@ class DCCA_SDL(DCCA):
         >>> import torch.nn as nn
         >>> enc1 = nn.Linear(10, 4)
         >>> enc2 = nn.Linear(8, 4)
-        >>> model = DCCA_SDL(latent_dimensions=4, encoders=[enc1, enc2], lam=0.5)
+        >>> model = DCCASDL(latent_dimensions=4, encoders=[enc1, enc2], lam=0.5)
     """
 
     def __init__(
@@ -119,3 +120,8 @@ class DCCA_SDL(DCCA):
             "l2": l2,
             "sdl": sdl,
         }
+
+
+@deprecated("Renamed to DCCASDL for sklearn-style naming; use DCCASDL instead.")
+class DCCA_SDL(DCCASDL):
+    pass

--- a/cca_zoo/gam/_gamcca.py
+++ b/cca_zoo/gam/_gamcca.py
@@ -201,7 +201,7 @@ class GAMCCA(BaseModel):
     cross-covariance (including $i = j$ terms) and $V$ the mean
     auto-covariance across all views (see :mod:`cca_zoo._utils._ey`, the
     same shared EY-loss machinery used by
-    :class:`~cca_zoo.linear.gradient.CCA_EY`, :class:`~cca_zoo.deep.DCCA_EY`,
+    :class:`~cca_zoo.linear.gradient.CCAEY`, :class:`~cca_zoo.deep.DCCAEY`,
     and :class:`~cca_zoo.tree.TreeCCA`).
 
     Unlike those models, which reach the EY loss's optimum by many small

--- a/cca_zoo/gp/__init__.py
+++ b/cca_zoo/gp/__init__.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
-from cca_zoo.gp._gpcca import GPCCA
+from cca_zoo.gp._gpcca import GPCCA as GPCCA
+from cca_zoo.gp._gpcca import GaussianProcessCCA
 
-__all__ = ["GPCCA"]
+__all__ = ["GaussianProcessCCA"]
+# Deprecated alias GPCCA stays importable for backward compatibility but is
+# intentionally left out of __all__/docs.

--- a/cca_zoo/gp/_gpcca.py
+++ b/cca_zoo/gp/_gpcca.py
@@ -1,4 +1,4 @@
-"""GPCCA — Gaussian-process Canonical Correlation Analysis."""
+"""GaussianProcessCCA — Gaussian-process Canonical Correlation Analysis."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from scipy.linalg import cho_solve, cholesky, solve_triangular
 from sklearn.cluster import kmeans_plusplus
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import RBF, ConstantKernel
+from sklearn.utils import deprecated
 from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import check_is_fitted
 
@@ -208,7 +209,7 @@ class _SparseGpEncoder(_GpEncoder):
 
     where $\Lambda = \operatorname{diag}(\alpha)$ is the (heteroscedastic)
     per-sample noise variance — here the same diagonal-Hessian weight used
-    throughout GPCCA. This costs $O(n m^2 + m^3)$: linear rather than
+    throughout GaussianProcessCCA. This costs $O(n m^2 + m^3)$: linear rather than
     cubic in $n$, at the price of an approximation whose quality depends
     on how well $m$ inducing points span the data.
 
@@ -356,8 +357,8 @@ class _SparseGpEncoder(_GpEncoder):
         return mean
 
 
-class GPCCA(BaseModel):
-    r"""GPCCA — nonlinear multiview CCA with Gaussian-process encoders.
+class GaussianProcessCCA(BaseModel):
+    r"""GaussianProcessCCA — nonlinear multiview CCA with Gaussian-process encoders.
 
     Learns one nonlinear encoder $f_i$ per view — a Gaussian process with
     an ARD (per-feature-lengthscale) RBF kernel over that view's *raw,
@@ -469,11 +470,11 @@ class GPCCA(BaseModel):
         >>> rng = np.random.default_rng(0)
         >>> X1 = rng.standard_normal((100, 3))
         >>> X2 = rng.standard_normal((100, 3))
-        >>> model = GPCCA(latent_dimensions=1).fit([X1, X2])
+        >>> model = GaussianProcessCCA(latent_dimensions=1).fit([X1, X2])
         >>> scores = model.transform([X1, X2])
         >>> means, stds = model.transform([X1, X2], return_std=True)
         >>> # For larger datasets, cap inference cost with inducing points:
-        >>> big_model = GPCCA(latent_dimensions=1, n_inducing=200)
+        >>> big_model = GaussianProcessCCA(latent_dimensions=1, n_inducing=200)
     """
 
     _parameter_constraints: ClassVar[dict[str, list[Any]]] = {
@@ -504,8 +505,8 @@ class GPCCA(BaseModel):
         self.n_inducing = n_inducing
         self.random_state = random_state
 
-    def fit(self, views: list[ArrayLike], y: None = None) -> GPCCA:
-        """Fit the GPCCA model.
+    def fit(self, views: list[ArrayLike], y: None = None) -> GaussianProcessCCA:
+        """Fit the GaussianProcessCCA model.
 
         Args:
             views: List of 2 or more arrays, each (n_samples, n_features_i).
@@ -614,11 +615,11 @@ class GPCCA(BaseModel):
 
     @property
     def weights(self) -> list[np.ndarray]:
-        """Not implemented for GPCCA.
+        """Not implemented for GaussianProcessCCA.
 
         Raises:
             sklearn.exceptions.NotFittedError: If ``fit`` has not been called.
-            NotImplementedError: GPCCA encoders are Gaussian processes over
+            NotImplementedError: GaussianProcessCCA encoders are Gaussian processes over
                 the joint feature vector, not linear weight matrices, and
                 have no per-feature decomposition analogous to
                 :meth:`~cca_zoo.gam.GAMCCA.shape_function` (the kernel is
@@ -626,8 +627,16 @@ class GPCCA(BaseModel):
         """
         check_is_fitted(self)
         raise NotImplementedError(
-            "GPCCA has no linear weight matrices; its encoders are "
+            "GaussianProcessCCA has no linear weight matrices; its encoders are "
             "Gaussian processes with a joint (non-additive) kernel over "
             "each view's raw features, so there is no per-feature "
             "decomposition to expose."
         )
+
+
+@deprecated(
+    "Renamed to GaussianProcessCCA for sklearn-style naming "
+    "(matching GaussianProcessRegressor/Classifier); use GaussianProcessCCA instead."
+)
+class GPCCA(GaussianProcessCCA):
+    pass

--- a/cca_zoo/gp/_gpcca.py
+++ b/cca_zoo/gp/_gpcca.py
@@ -372,7 +372,7 @@ class GPCCA(BaseModel):
     cross-covariance (including $i = j$ terms) and $V$ the mean
     auto-covariance across all views (see :mod:`cca_zoo._utils._ey`, the
     same shared EY-loss machinery used by
-    :class:`~cca_zoo.linear.gradient.CCA_EY`, :class:`~cca_zoo.deep.DCCA_EY`,
+    :class:`~cca_zoo.linear.gradient.CCAEY`, :class:`~cca_zoo.deep.DCCAEY`,
     :class:`~cca_zoo.tree.TreeCCA`, and :class:`~cca_zoo.gam.GAMCCA`).
 
     Unlike :class:`~cca_zoo.gam.GAMCCA`'s per-feature additive splines, a

--- a/cca_zoo/linear/__init__.py
+++ b/cca_zoo/linear/__init__.py
@@ -18,14 +18,18 @@ from ._iterative import (
     SCCA_PMD,
     ElasticCCA,
     ParkhomenkoCCA,
-    SCCA_Span,
+    SCCASpan,
 )
+from ._iterative import SCCA_Span as SCCA_Span
 from ._mcca import MCCA
 from ._partialcca import PartialCCA
 from ._pls import PLS
 from ._rcca import rCCA
 from ._tcca import TCCA
-from .gradient import CCA_EY, MCCA_EY, PLS_EY
+from .gradient import CCA_EY as CCA_EY
+from .gradient import CCAEY, MCCAEY, PLSEY
+from .gradient import MCCA_EY as MCCA_EY
+from .gradient import PLS_EY as PLS_EY
 
 __all__ = [
     # Exact eigendecomposition
@@ -41,16 +45,21 @@ __all__ = [
     # Reduced-rank regression
     "CCAR3",
     # Gradient descent (high-dimensional / streaming)
-    "PLS_EY",
-    "CCA_EY",
-    "MCCA_EY",
+    "PLSEY",
+    "CCAEY",
+    "MCCAEY",
     # Sparse / regularised ALS
     "SCCA_PMD",
     "SCCA_ADMM",
     "SCCA_IPLS",
-    "SCCA_Span",
+    "SCCASpan",
     "ElasticCCA",
     "ParkhomenkoCCA",
     "SAR",
     "PLS_ALS",
 ]
+# Deprecated underscored aliases (CCA_EY, MCCA_EY, PLS_EY, SCCA_Span) stay
+# importable for backward compatibility via the `from .gradient import ...`
+# / `from ._iterative import ...` statements above, but are intentionally
+# left out of __all__ (and therefore out of the API docs) since they are
+# being removed in a future release.

--- a/cca_zoo/linear/__init__.py
+++ b/cca_zoo/linear/__init__.py
@@ -10,16 +10,20 @@ from ._cca import CCA
 from ._ccar3 import CCAR3
 from ._gcca import GCCA
 from ._grcca import GRCCA
+from ._iterative import PLS_ALS as PLS_ALS
 from ._iterative import (
-    PLS_ALS,
+    PLSALS,
     SAR,
-    SCCA_ADMM,
-    SCCA_IPLS,
-    SCCA_PMD,
+    SCCAADMM,
+    SCCAIPLS,
+    SCCAPMD,
     ElasticCCA,
     ParkhomenkoCCA,
     SCCASpan,
 )
+from ._iterative import SCCA_ADMM as SCCA_ADMM
+from ._iterative import SCCA_IPLS as SCCA_IPLS
+from ._iterative import SCCA_PMD as SCCA_PMD
 from ._iterative import SCCA_Span as SCCA_Span
 from ._mcca import MCCA
 from ._partialcca import PartialCCA
@@ -49,17 +53,18 @@ __all__ = [
     "CCAEY",
     "MCCAEY",
     # Sparse / regularised ALS
-    "SCCA_PMD",
-    "SCCA_ADMM",
-    "SCCA_IPLS",
+    "SCCAPMD",
+    "SCCAADMM",
+    "SCCAIPLS",
     "SCCASpan",
     "ElasticCCA",
     "ParkhomenkoCCA",
     "SAR",
-    "PLS_ALS",
+    "PLSALS",
 ]
-# Deprecated underscored aliases (CCA_EY, MCCA_EY, PLS_EY, SCCA_Span) stay
-# importable for backward compatibility via the `from .gradient import ...`
-# / `from ._iterative import ...` statements above, but are intentionally
-# left out of __all__ (and therefore out of the API docs) since they are
-# being removed in a future release.
+# Deprecated underscored aliases (CCA_EY, MCCA_EY, PLS_EY, SCCA_PMD,
+# SCCA_ADMM, SCCA_IPLS, SCCA_Span, PLS_ALS) stay importable for backward
+# compatibility via the `from .gradient import ...` / `from ._iterative
+# import ...` statements above, but are intentionally left out of __all__
+# (and therefore out of the API docs) since they are being removed in a
+# future release.

--- a/cca_zoo/linear/_iterative.py
+++ b/cca_zoo/linear/_iterative.py
@@ -4,10 +4,10 @@ All classes in this module use an Alternating Least Squares (ALS) loop with
 optional deflation to extract multiple canonical directions.
 
 Classes:
-    PLS_ALS: ALS variant of PLS (simple power iteration).
-    SCCA_PMD: Sparse CCA via Penalized Matrix Decomposition (Witten 2009).
-    SCCA_ADMM: Sparse CCA via ADMM (Suo 2017).
-    SCCA_IPLS: Iterative PLS with lasso penalty (Mai & Zhang 2019).
+    PLSALS: ALS variant of PLS (simple power iteration).
+    SCCAPMD: Sparse CCA via Penalized Matrix Decomposition (Witten 2009).
+    SCCAADMM: Sparse CCA via ADMM (Suo 2017).
+    SCCAIPLS: Iterative PLS with lasso penalty (Mai & Zhang 2019).
     SCCASpan: hard-thresholding ALS inspired by SpanCCA (Asteris 2016).
     ElasticCCA: Elastic net regularised CCA (Waaijenborg 2008).
     ParkhomenkoCCA: Sparse CCA via soft-thresholding (Parkhomenko 2009).
@@ -161,11 +161,11 @@ def _target_score(
 
 
 # ---------------------------------------------------------------------------
-# PLS_ALS — ALS variant of PLS
+# PLSALS — ALS variant of PLS
 # ---------------------------------------------------------------------------
 
 
-class PLS_ALS(_BaseIterative):
+class PLSALS(_BaseIterative):
     r"""Alternating Least Squares variant of Partial Least Squares.
 
     Maximises the sum of cross-view covariances using simple power-iteration
@@ -198,7 +198,7 @@ class PLS_ALS(_BaseIterative):
         >>> rng = np.random.default_rng(0)
         >>> X1 = rng.standard_normal((50, 10))
         >>> X2 = rng.standard_normal((50, 8))
-        >>> model = PLS_ALS(latent_dimensions=2, random_state=0).fit([X1, X2])
+        >>> model = PLSALS(latent_dimensions=2, random_state=0).fit([X1, X2])
     """
 
     def _update_weight(
@@ -226,7 +226,7 @@ class PLS_ALS(_BaseIterative):
 
 
 # ---------------------------------------------------------------------------
-# SCCA_PMD — Penalized Matrix Decomposition (Witten 2009)
+# SCCAPMD — Penalized Matrix Decomposition (Witten 2009)
 # ---------------------------------------------------------------------------
 
 
@@ -234,7 +234,7 @@ def _bisect_threshold(x: np.ndarray, l1_bound: float) -> np.ndarray:
     """Find the soft threshold that makes the L2-normalised thresholded
     vector's L1 norm equal ``l1_bound``.
 
-    ``l1_bound`` (``tau * sqrt(p)``, see :class:`SCCA_PMD`) is only a
+    ``l1_bound`` (``tau * sqrt(p)``, see :class:`SCCAPMD`) is only a
     meaningful constraint on a *unit-L2-norm* vector: ``||w||_1 <= sqrt(p)``
     for ``||w||_2 = 1`` is the Cauchy-Schwarz bound the ``tau in (0, 1]``
     parameterisation relies on. The bisection therefore has to search on
@@ -245,7 +245,7 @@ def _bisect_threshold(x: np.ndarray, l1_bound: float) -> np.ndarray:
     optimal ``delta`` by the same ``c`` and leaves the ratio unchanged),
     whereas the raw L1 norm is not. ``x`` here is an un-normalised
     power-iteration update whose scale depends on the data
-    (:meth:`SCCA_PMD._update_weight` passes ``views[i].T @ target``,
+    (:meth:`SCCAPMD._update_weight` passes ``views[i].T @ target``,
     typically :math:`O(\\sqrt{n})` in magnitude for standardised data),
     not on ``tau``, so comparing that raw L1 norm directly against
     ``l1_bound`` made the constraint's effective strength depend on the
@@ -286,7 +286,7 @@ def _bisect_threshold(x: np.ndarray, l1_bound: float) -> np.ndarray:
     return result
 
 
-class SCCA_PMD(_BaseIterative):
+class SCCAPMD(_BaseIterative):
     r"""Sparse CCA via Penalized Matrix Decomposition.
 
     Maximises the cross-view covariance subject to L1 norm constraints on
@@ -323,7 +323,7 @@ class SCCA_PMD(_BaseIterative):
         >>> rng = np.random.default_rng(0)
         >>> X1 = rng.standard_normal((50, 10))
         >>> X2 = rng.standard_normal((50, 8))
-        >>> model = SCCA_PMD(tau=0.5, random_state=0).fit([X1, X2])
+        >>> model = SCCAPMD(tau=0.5, random_state=0).fit([X1, X2])
     """
 
     def __init__(
@@ -344,8 +344,8 @@ class SCCA_PMD(_BaseIterative):
         )
         self.tau = tau
 
-    def fit(self, views: list[ArrayLike], y: None = None) -> SCCA_PMD:
-        """Fit the SCCA_PMD model.
+    def fit(self, views: list[ArrayLike], y: None = None) -> SCCAPMD:
+        """Fit the SCCAPMD model.
 
         Args:
             views: List of arrays, each (n_samples, n_features_i).
@@ -409,11 +409,11 @@ class SCCA_PMD(_BaseIterative):
 
 
 # ---------------------------------------------------------------------------
-# SCCA_ADMM — ADMM-based sparse CCA (Suo 2017)
+# SCCAADMM — ADMM-based sparse CCA (Suo 2017)
 # ---------------------------------------------------------------------------
 
 
-class SCCA_ADMM(_BaseIterative):
+class SCCAADMM(_BaseIterative):
     r"""Sparse CCA via Alternating Direction Method of Multipliers.
 
     Solves the sparse CCA problem using ADMM to enforce both the L1 sparsity
@@ -457,7 +457,7 @@ class SCCA_ADMM(_BaseIterative):
         >>> rng = np.random.default_rng(0)
         >>> X1 = rng.standard_normal((50, 10))
         >>> X2 = rng.standard_normal((50, 8))
-        >>> model = SCCA_ADMM(tau=0.1, random_state=0).fit([X1, X2])
+        >>> model = SCCAADMM(tau=0.1, random_state=0).fit([X1, X2])
     """
 
     def __init__(
@@ -529,7 +529,7 @@ class SCCA_ADMM(_BaseIterative):
         weights: list[np.ndarray],
         i: int,
     ) -> np.ndarray:
-        """Not used — SCCA_ADMM overrides _fit_single directly.
+        """Not used — SCCAADMM overrides _fit_single directly.
 
         Args:
             views: View arrays (unused).
@@ -543,11 +543,11 @@ class SCCA_ADMM(_BaseIterative):
 
 
 # ---------------------------------------------------------------------------
-# SCCA_IPLS — Iterative PLS (Mai & Zhang 2019)
+# SCCAIPLS — Iterative PLS (Mai & Zhang 2019)
 # ---------------------------------------------------------------------------
 
 
-class SCCA_IPLS(_BaseIterative):
+class SCCAIPLS(_BaseIterative):
     r"""Iterative PLS with elastic net penalty on weight vectors.
 
     Alternates between penalised regression sub-problems.  For view $i$:
@@ -583,7 +583,7 @@ class SCCA_IPLS(_BaseIterative):
         >>> rng = np.random.default_rng(0)
         >>> X1 = rng.standard_normal((50, 10))
         >>> X2 = rng.standard_normal((50, 8))
-        >>> model = SCCA_IPLS(alpha=0.1, random_state=0).fit([X1, X2])
+        >>> model = SCCAIPLS(alpha=0.1, random_state=0).fit([X1, X2])
     """
 
     def __init__(
@@ -881,7 +881,7 @@ class ParkhomenkoCCA(_BaseIterative):
     standardisation, this is implemented by standardising each view to unit
     per-feature variance once per latent dimension (on top of the existing
     mean-centring), then running the same power iteration
-    :class:`SCCA_PMD`'s raw-covariance methods use on that standardised
+    :class:`SCCAPMD`'s raw-covariance methods use on that standardised
     data, with a fixed soft-threshold $\tau_i$ in place of the adaptive
     bisection search:
 
@@ -1236,8 +1236,28 @@ def _make_regressors(
 
 
 # ---------------------------------------------------------------------------
-# Deprecated underscored alias (removed in a future release)
+# Deprecated underscored aliases (removed in a future release)
 # ---------------------------------------------------------------------------
+
+
+@deprecated("Renamed to PLSALS for sklearn-style naming; use PLSALS instead.")
+class PLS_ALS(PLSALS):
+    pass
+
+
+@deprecated("Renamed to SCCAPMD for sklearn-style naming; use SCCAPMD instead.")
+class SCCA_PMD(SCCAPMD):
+    pass
+
+
+@deprecated("Renamed to SCCAADMM for sklearn-style naming; use SCCAADMM instead.")
+class SCCA_ADMM(SCCAADMM):
+    pass
+
+
+@deprecated("Renamed to SCCAIPLS for sklearn-style naming; use SCCAIPLS instead.")
+class SCCA_IPLS(SCCAIPLS):
+    pass
 
 
 @deprecated("Renamed to SCCASpan for sklearn-style naming; use SCCASpan instead.")

--- a/cca_zoo/linear/_iterative.py
+++ b/cca_zoo/linear/_iterative.py
@@ -8,7 +8,7 @@ Classes:
     SCCA_PMD: Sparse CCA via Penalized Matrix Decomposition (Witten 2009).
     SCCA_ADMM: Sparse CCA via ADMM (Suo 2017).
     SCCA_IPLS: Iterative PLS with lasso penalty (Mai & Zhang 2019).
-    SCCA_Span: hard-thresholding ALS inspired by SpanCCA (Asteris 2016).
+    SCCASpan: hard-thresholding ALS inspired by SpanCCA (Asteris 2016).
     ElasticCCA: Elastic net regularised CCA (Waaijenborg 2008).
     ParkhomenkoCCA: Sparse CCA via soft-thresholding (Parkhomenko 2009).
     SAR: Sparse Alternating Regression, BIC-selected (Wilms & Croux 2015).
@@ -23,6 +23,7 @@ from typing import cast
 import numpy as np
 from numpy.typing import ArrayLike
 from sklearn.linear_model import ElasticNet, Lasso, Ridge, lasso_path
+from sklearn.utils import deprecated
 
 from cca_zoo._base import BaseModel
 from cca_zoo._utils._linalg import deflate, soft_threshold
@@ -651,11 +652,11 @@ class SCCA_IPLS(_BaseIterative):
 
 
 # ---------------------------------------------------------------------------
-# SCCA_Span — hard-thresholding ALS inspired by SpanCCA (Asteris 2016)
+# SCCASpan — hard-thresholding ALS inspired by SpanCCA (Asteris 2016)
 # ---------------------------------------------------------------------------
 
 
-class SCCA_Span(_BaseIterative):
+class SCCASpan(_BaseIterative):
     r"""Hard-thresholding ALS for sparse CCA, inspired by SpanCCA.
 
     Solves sparse CCA by an alternating least squares loop where each
@@ -690,7 +691,7 @@ class SCCA_Span(_BaseIterative):
         >>> rng = np.random.default_rng(0)
         >>> X1 = rng.standard_normal((50, 10))
         >>> X2 = rng.standard_normal((50, 8))
-        >>> model = SCCA_Span(span=5, random_state=0).fit([X1, X2])
+        >>> model = SCCASpan(span=5, random_state=0).fit([X1, X2])
     """
 
     def __init__(
@@ -1045,7 +1046,7 @@ class SAR(_BaseIterative):
     every other alternating-regression method in this module. The
     multiview generalisation (each view regressed against the summed
     score of every *other* view, via the same :func:`_target_score`
-    helper :class:`SCCA_Span`, :class:`ParkhomenkoCCA`, and
+    helper :class:`SCCASpan`, :class:`ParkhomenkoCCA`, and
     :class:`ElasticCCA` use) is this implementation's own extension,
     not something the two-view paper itself considers.
 
@@ -1232,3 +1233,13 @@ def _make_regressors(
                 )
             )
     return regressors
+
+
+# ---------------------------------------------------------------------------
+# Deprecated underscored alias (removed in a future release)
+# ---------------------------------------------------------------------------
+
+
+@deprecated("Renamed to SCCASpan for sklearn-style naming; use SCCASpan instead.")
+class SCCA_Span(SCCASpan):
+    pass

--- a/cca_zoo/linear/gradient/__init__.py
+++ b/cca_zoo/linear/gradient/__init__.py
@@ -6,13 +6,18 @@ eigendecomposition used by the exact linear models. See
 :mod:`cca_zoo._utils._ey` for the shared EY-loss machinery.
 
 Classes:
-    PLS_EY: Eckart-Young PLS.
-    CCA_EY: Eckart-Young CCA (whitened).
-    MCCA_EY: Multiview extension of CCA_EY (>=2 views).
+    PLSEY: Eckart-Young PLS.
+    CCAEY: Eckart-Young CCA (whitened).
+    MCCAEY: Multiview extension of CCAEY (>=2 views).
 """
 
-from cca_zoo.linear.gradient._cca_ey import CCA_EY
-from cca_zoo.linear.gradient._mcca_ey import MCCA_EY
-from cca_zoo.linear.gradient._pls_ey import PLS_EY
+from cca_zoo.linear.gradient._cca_ey import CCA_EY as CCA_EY
+from cca_zoo.linear.gradient._cca_ey import CCAEY
+from cca_zoo.linear.gradient._mcca_ey import MCCA_EY as MCCA_EY
+from cca_zoo.linear.gradient._mcca_ey import MCCAEY
+from cca_zoo.linear.gradient._pls_ey import PLS_EY as PLS_EY
+from cca_zoo.linear.gradient._pls_ey import PLSEY
 
-__all__ = ["PLS_EY", "CCA_EY", "MCCA_EY"]
+__all__ = ["PLSEY", "CCAEY", "MCCAEY"]
+# Deprecated aliases PLS_EY, CCA_EY, MCCA_EY stay importable for backward
+# compatibility but are intentionally left out of __all__/docs.

--- a/cca_zoo/linear/gradient/_base.py
+++ b/cca_zoo/linear/gradient/_base.py
@@ -83,7 +83,7 @@ class BaseGradientModel(BaseModel):
     ) -> list[np.ndarray]:
         """Cheap, data-independent orthonormal initial weights, one per view.
 
-        The default for this base class; :class:`~cca_zoo.linear.gradient.CCA_EY`
+        The default for this base class; :class:`~cca_zoo.linear.gradient.CCAEY`
         overrides this with a data-informed initialisation more appropriate
         to its own loss (see
         :func:`cca_zoo._utils._ey.cheap_orthonormal_projection_weights`).

--- a/cca_zoo/linear/gradient/_cca_ey.py
+++ b/cca_zoo/linear/gradient/_cca_ey.py
@@ -1,4 +1,4 @@
-"""CCA_EY — Eckart-Young CCA, continuously blended with PLS_EY via a ridge parameter."""
+"""CCAEY — Eckart-Young CCA, continuously blended with PLSEY via a ridge parameter."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ from typing import Any, ClassVar
 
 import numpy as np
 from numpy.typing import ArrayLike
+from sklearn.utils import deprecated
 from sklearn.utils._param_validation import Interval
 
 from cca_zoo._utils._ey import (
@@ -17,8 +18,8 @@ from cca_zoo._utils._ey import (
 from cca_zoo.linear.gradient._base import BaseGradientModel
 
 
-class CCA_EY(BaseGradientModel):
-    r"""Eckart-Young CCA for large-scale data, ridge-blended with PLS_EY.
+class CCAEY(BaseGradientModel):
+    r"""Eckart-Young CCA for large-scale data, ridge-blended with PLSEY.
 
     Optimises the unconstrained Eckart-Young (EY) objective by mini-batch
     momentum gradient descent directly on the raw (centred) views, with no
@@ -27,8 +28,8 @@ class CCA_EY(BaseGradientModel):
     reformulation folds the orthonormalising pressure into the loss itself,
     so a full-batch preprocessing pass over the data is never needed. This
     matches how the same underlying loss is used, unwhitened, by
-    :class:`~cca_zoo.linear.gradient.PLS_EY`, :class:`~cca_zoo.tree.TreeCCA`,
-    and :class:`~cca_zoo.deep.DCCA_EY`.
+    :class:`~cca_zoo.linear.gradient.PLSEY`, :class:`~cca_zoo.tree.TreeCCA`,
+    and :class:`~cca_zoo.deep.DCCAEY`.
 
     For embeddings $Z_i = X_i W_i$, let $C$ and $V$ be the mean
     pairwise cross-covariance and mean auto-covariance across views (see
@@ -46,12 +47,12 @@ class CCA_EY(BaseGradientModel):
     \mathcal{L}_{EY}(c) = -2 \operatorname{tr}(C - c V) + \operatorname{tr}(V_c V_c)
     $$
 
-    ``c=0`` recovers plain (unregularised) ``CCA_EY`` exactly; ``c=1``
-    recovers :class:`~cca_zoo.linear.gradient.PLS_EY`'s loss exactly (its
+    ``c=0`` recovers plain (unregularised) ``CCAEY`` exactly; ``c=1``
+    recovers :class:`~cca_zoo.linear.gradient.PLSEY`'s loss exactly (its
     reward excludes the $i=j$ terms that $\mathcal{L}_{EY}(0)$
     includes, and its penalty is purely $\operatorname{tr}(BB)$) —
     both endpoints, and the gradient at intermediate $c$, are verified
-    against finite differences and against ``PLS_EY``'s own independently
+    against finite differences and against ``PLSEY``'s own independently
     verified gradient. This objective has the canonical directions as a
     stationary point without requiring an explicit orthonormality
     constraint, unlike a plain squared-projection-distance loss.
@@ -83,8 +84,8 @@ class CCA_EY(BaseGradientModel):
     Args:
         latent_dimensions: Number of latent dimensions. Default is 1.
         center: Whether to subtract column means. Default True.
-        c: Ridge blend in ``[0, 1]`` between ``CCA_EY`` (0) and ``PLS_EY``
-            (1). Default is 0 (standard, unregularised CCA_EY); see the
+        c: Ridge blend in ``[0, 1]`` between ``CCAEY`` (0) and ``PLSEY``
+            (1). Default is 0 (standard, unregularised CCAEY); see the
             note above on numerical stability for high-dimensional data.
         learning_rate: Gradient step size. Default is 1e-2.
         max_iter: Number of gradient steps. Default is 1000.
@@ -98,7 +99,7 @@ class CCA_EY(BaseGradientModel):
         >>> rng = np.random.default_rng(0)
         >>> X1 = rng.standard_normal((5000, 200))
         >>> X2 = rng.standard_normal((5000, 150))
-        >>> model = CCA_EY(latent_dimensions=4, batch_size=128, random_state=0)
+        >>> model = CCAEY(latent_dimensions=4, batch_size=128, random_state=0)
         >>> model = model.fit([X1, X2])
     """
 
@@ -131,8 +132,8 @@ class CCA_EY(BaseGradientModel):
         )
         self.c = c
 
-    def fit(self, views: list[ArrayLike], y: None = None) -> CCA_EY:
-        """Fit CCA_EY by mini-batch momentum gradient descent.
+    def fit(self, views: list[ArrayLike], y: None = None) -> CCAEY:
+        """Fit CCAEY by mini-batch momentum gradient descent.
 
         Args:
             views: List of arrays, each (n_samples, n_features_i).
@@ -176,12 +177,12 @@ class CCA_EY(BaseGradientModel):
         r"""Analytic gradient of $\mathcal{L}_{EY}(c)$ w.r.t. each $W_k$.
 
         Combines the chain-rule gradient through the embeddings (as for
-        plain ``CCA_EY``, scaled by ``(1 - c)`` plus a direct
+        plain ``CCAEY``, scaled by ``(1 - c)`` plus a direct
         ``c``-scaled reward correction) with a *direct* weight-space
         gradient contribution from ``B``'s dependence on $W_k$ (as for
-        ``PLS_EY``, scaled by ``c``). Verified against finite differences
+        ``PLSEY``, scaled by ``c``). Verified against finite differences
         for ``c`` in ``{0, 0.3, 0.5, 0.7, 1}``, and, at ``c=0``/``c=1``,
-        against the unregularised ``CCA_EY`` gradient and ``PLS_EY``'s own
+        against the unregularised ``CCAEY`` gradient and ``PLSEY``'s own
         gradient respectively (both matches exact).
 
         Args:
@@ -223,3 +224,8 @@ class CCA_EY(BaseGradientModel):
         v_blend = (1 - c) * v_data + c * b
         reward = C - c * v_data
         return float(-2.0 * np.trace(reward) + np.trace(v_blend @ v_blend))
+
+
+@deprecated("Renamed to CCAEY for sklearn-style naming; use CCAEY instead.")
+class CCA_EY(CCAEY):
+    pass

--- a/cca_zoo/linear/gradient/_mcca_ey.py
+++ b/cca_zoo/linear/gradient/_mcca_ey.py
@@ -1,16 +1,17 @@
-"""MCCA_EY — Multiview Eckart-Young CCA."""
+"""MCCAEY — Multiview Eckart-Young CCA."""
 
 from __future__ import annotations
 
 from numpy.typing import ArrayLike
+from sklearn.utils import deprecated
 
-from cca_zoo.linear.gradient._cca_ey import CCA_EY
+from cca_zoo.linear.gradient._cca_ey import CCAEY
 
 
-class MCCA_EY(CCA_EY):
+class MCCAEY(CCAEY):
     r"""Eckart-Young multiview CCA for large-scale data (>=2 views).
 
-    Identical to :class:`CCA_EY`; the shared Eckart-Young loss and its
+    Identical to :class:`CCAEY`; the shared Eckart-Young loss and its
     gradient (see :mod:`cca_zoo._utils._ey`) are already defined for an
     arbitrary number of views, so no multiview-specific logic is needed here.
 
@@ -22,9 +23,9 @@ class MCCA_EY(CCA_EY):
     Args:
         latent_dimensions: Number of latent dimensions. Default is 1.
         center: Whether to subtract column means. Default True.
-        c: Ridge blend in ``[0, 1]`` between ``CCA_EY``-like (0) and
-            ``PLS_EY``-like (1) behaviour. Default is 0; see
-            :class:`CCA_EY`'s docstring for the numerical-stability note on
+        c: Ridge blend in ``[0, 1]`` between ``CCAEY``-like (0) and
+            ``PLSEY``-like (1) behaviour. Default is 0; see
+            :class:`CCAEY`'s docstring for the numerical-stability note on
             high-dimensional data.
         learning_rate: Gradient step size. Default is 1e-2.
         max_iter: Number of gradient steps. Default is 1000.
@@ -39,12 +40,12 @@ class MCCA_EY(CCA_EY):
         >>> X1 = rng.standard_normal((5000, 200))
         >>> X2 = rng.standard_normal((5000, 150))
         >>> X3 = rng.standard_normal((5000, 100))
-        >>> model = MCCA_EY(latent_dimensions=4, batch_size=128, random_state=0)
+        >>> model = MCCAEY(latent_dimensions=4, batch_size=128, random_state=0)
         >>> model = model.fit([X1, X2, X3])
     """
 
-    def fit(self, views: list[ArrayLike], y: None = None) -> MCCA_EY:
-        """Fit MCCA_EY for 2 or more views.
+    def fit(self, views: list[ArrayLike], y: None = None) -> MCCAEY:
+        """Fit MCCAEY for 2 or more views.
 
         Args:
             views: List of arrays, each (n_samples, n_features_i).
@@ -59,3 +60,8 @@ class MCCA_EY(CCA_EY):
         """
         super().fit(views, y)
         return self
+
+
+@deprecated("Renamed to MCCAEY for sklearn-style naming; use MCCAEY instead.")
+class MCCA_EY(MCCAEY):
+    pass

--- a/cca_zoo/linear/gradient/_pls_ey.py
+++ b/cca_zoo/linear/gradient/_pls_ey.py
@@ -1,19 +1,20 @@
-"""PLS_EY — stochastic Eckart-Young PLS (c=1 special case of CCA_EY)."""
+"""PLSEY — stochastic Eckart-Young PLS (c=1 special case of CCAEY)."""
 
 from __future__ import annotations
 
 import numpy as np
 from numpy.typing import ArrayLike
+from sklearn.utils import deprecated
 
 from cca_zoo._utils._ey import random_orthonormal_weights
-from cca_zoo.linear.gradient._cca_ey import CCA_EY
+from cca_zoo.linear.gradient._cca_ey import CCAEY
 
 
-class PLS_EY(CCA_EY):
+class PLSEY(CCAEY):
     r"""Stochastic Eckart-Young PLS for large-scale data.
 
-    This is equivalent to :class:`~cca_zoo.linear.gradient.CCA_EY` with
-    ``c=1``: the reward excludes the $i = j$ terms that ``CCA_EY``'s
+    This is equivalent to :class:`~cca_zoo.linear.gradient.CCAEY` with
+    ``c=1``: the reward excludes the $i = j$ terms that ``CCAEY``'s
     ($c=0$) reward includes, and the penalty is purely
     $\operatorname{tr}(BB)$ on the weight Gram matrix $B$, which
     drives the weights towards (approximate) orthonormality at the optimum
@@ -24,7 +25,7 @@ class PLS_EY(CCA_EY):
 
     Initial weights have exactly orthonormal columns (unit-norm, mutually
     orthogonal) before any gradient step, matching the shape of this loss's
-    own penalty on $B$ — unlike :class:`~cca_zoo.linear.gradient.CCA_EY`'s
+    own penalty on $B$ — unlike :class:`~cca_zoo.linear.gradient.CCAEY`'s
     own data-informed default, which instead orthonormalises the initial
     *projections* (see :func:`cca_zoo._utils._ey.random_orthonormal_weights`
     vs. :func:`cca_zoo._utils._ey.cheap_orthonormal_projection_weights`).
@@ -49,7 +50,7 @@ class PLS_EY(CCA_EY):
         >>> rng = np.random.default_rng(0)
         >>> X1 = rng.standard_normal((200, 500))
         >>> X2 = rng.standard_normal((200, 400))
-        >>> model = PLS_EY(latent_dimensions=4, batch_size=64, random_state=0)
+        >>> model = PLSEY(latent_dimensions=4, batch_size=64, random_state=0)
         >>> model = model.fit([X1, X2])
     """
 
@@ -76,8 +77,8 @@ class PLS_EY(CCA_EY):
             random_state=random_state,
         )
 
-    def fit(self, views: list[ArrayLike], y: None = None) -> PLS_EY:
-        """Fit PLS_EY by mini-batch momentum gradient descent.
+    def fit(self, views: list[ArrayLike], y: None = None) -> PLSEY:
+        """Fit PLSEY by mini-batch momentum gradient descent.
 
         Args:
             views: List of arrays, each (n_samples, n_features_i).
@@ -97,8 +98,13 @@ class PLS_EY(CCA_EY):
     ) -> list[np.ndarray]:
         """Plain orthonormal-weight initial weights (see class docstring).
 
-        Overrides :class:`~cca_zoo.linear.gradient.CCA_EY`'s data-informed
+        Overrides :class:`~cca_zoo.linear.gradient.CCAEY`'s data-informed
         default, since this loss's own penalty targets weight-space
         orthonormality rather than projection-space decorrelation.
         """
         return random_orthonormal_weights(views, self.latent_dimensions, rng)
+
+
+@deprecated("Renamed to PLSEY for sklearn-style naming; use PLSEY instead.")
+class PLS_EY(PLSEY):
+    pass

--- a/cca_zoo/tree/_treecca.py
+++ b/cca_zoo/tree/_treecca.py
@@ -139,8 +139,8 @@ class TreeCCA(BaseModel):
     pairwise cross-covariance (including $i = j$ terms) and $V$
     the mean auto-covariance across all views (see
     :mod:`cca_zoo._utils._ey`, the same shared EY-loss machinery used by
-    :class:`~cca_zoo.linear.gradient.CCA_EY` and
-    :class:`~cca_zoo.deep.DCCA_EY`). The encoders are fit by alternating
+    :class:`~cca_zoo.linear.gradient.CCAEY` and
+    :class:`~cca_zoo.deep.DCCAEY`). The encoders are fit by alternating
     (Gauss-Seidel) gradient boosting: each round, for every view in turn, one
     tree is added to each of its ``latent_dimensions`` boosters using the
     EY-loss gradient (rescaled to a fixed target standard deviation for

--- a/docs/api/deep.md
+++ b/docs/api/deep.md
@@ -30,7 +30,7 @@ Deep CCA variants. Requires `pip install cca-zoo[deep]`.
 
 ---
 
-::: cca_zoo.deep.DCCA_EY
+::: cca_zoo.deep.DCCAEY
 
 ---
 

--- a/docs/api/deep.md
+++ b/docs/api/deep.md
@@ -34,11 +34,11 @@ Deep CCA variants. Requires `pip install cca-zoo[deep]`.
 
 ---
 
-::: cca_zoo.deep.DCCA_NOI
+::: cca_zoo.deep.DCCANOI
 
 ---
 
-::: cca_zoo.deep.DCCA_SDL
+::: cca_zoo.deep.DCCASDL
 
 ---
 

--- a/docs/api/gp.md
+++ b/docs/api/gp.md
@@ -5,4 +5,4 @@ Gaussian-process (GP) nonlinear CCA methods. Built entirely on scikit-learn's ow
 
 ---
 
-::: cca_zoo.gp.GPCCA
+::: cca_zoo.gp.GaussianProcessCCA

--- a/docs/api/linear.md
+++ b/docs/api/linear.md
@@ -81,19 +81,19 @@ Linear CCA methods. All classes are `sklearn.base.BaseEstimator` subclasses.
 
 ## Sparse / iterative methods
 
-::: cca_zoo.linear.PLS_ALS
+::: cca_zoo.linear.PLSALS
 
 ---
 
-::: cca_zoo.linear.SCCA_PMD
+::: cca_zoo.linear.SCCAPMD
 
 ---
 
-::: cca_zoo.linear.SCCA_ADMM
+::: cca_zoo.linear.SCCAADMM
 
 ---
 
-::: cca_zoo.linear.SCCA_IPLS
+::: cca_zoo.linear.SCCAIPLS
 
 ---
 

--- a/docs/api/linear.md
+++ b/docs/api/linear.md
@@ -67,15 +67,15 @@ Linear CCA methods. All classes are `sklearn.base.BaseEstimator` subclasses.
 
 ## Gradient-descent methods
 
-::: cca_zoo.linear.PLS_EY
+::: cca_zoo.linear.PLSEY
 
 ---
 
-::: cca_zoo.linear.CCA_EY
+::: cca_zoo.linear.CCAEY
 
 ---
 
-::: cca_zoo.linear.MCCA_EY
+::: cca_zoo.linear.MCCAEY
 
 ---
 
@@ -97,7 +97,7 @@ Linear CCA methods. All classes are `sklearn.base.BaseEstimator` subclasses.
 
 ---
 
-::: cca_zoo.linear.SCCA_Span
+::: cca_zoo.linear.SCCASpan
 
 ---
 

--- a/docs/user-guide/deep.md
+++ b/docs/user-guide/deep.md
@@ -93,15 +93,15 @@ Available objectives (from `cca_zoo.deep.objectives`):
 | `GCCALoss` | Negative sum of top-$k$ eigenvalues of $\sum_i H_i H_i^\top$ |
 | `TCCALoss` | Negative Frobenius norm of whitened cross-moment tensor |
 
-### DCCA_EY — Eckart-Young objective
+### DCCAEY — Eckart-Young objective
 
 Uses the Eckart-Young decomposition as the differentiable objective (Benton et al. 2022).
 Tends to be more stable than the original CCA loss on small batches.
 
 ```python
-from cca_zoo.deep import DCCA_EY
+from cca_zoo.deep import DCCAEY
 
-model = DCCA_EY(latent_dimensions=8, encoders=[e1, e2])
+model = DCCAEY(latent_dimensions=8, encoders=[e1, e2])
 ```
 
 ### DCCA_NOI — Non-linear Orthogonal Iterations
@@ -254,7 +254,7 @@ print("Representation shape:", z1.shape)  # (1000, 4)
   `batch_size ≥ 4 * latent_dimensions` for stable estimates.
 - **Encoder output dimension ≥ `latent_dimensions`.** The model projects down inside the
   loss; do not make encoders narrower than the requested latent space.
-- **Use `DCCA_EY` for small batches.** The Eckart-Young objective is more numerically stable
+- **Use `DCCAEY` for small batches.** The Eckart-Young objective is more numerically stable
   than the original `CCALoss` when batch sizes are small.
 - **Score after training** via `model.score(loader)`, which fits a linear `MCCA` on the
   learned representations to report canonical correlations.

--- a/docs/user-guide/deep.md
+++ b/docs/user-guide/deep.md
@@ -104,26 +104,26 @@ from cca_zoo.deep import DCCAEY
 model = DCCAEY(latent_dimensions=8, encoders=[e1, e2])
 ```
 
-### DCCA_NOI — Non-linear Orthogonal Iterations
+### DCCANOI — Non-linear Orthogonal Iterations
 
 Wang et al. 2015. An iterative approach that alternately optimises each encoder
 while holding the others fixed.
 
 ```python
-from cca_zoo.deep import DCCA_NOI
+from cca_zoo.deep import DCCANOI
 
-model = DCCA_NOI(latent_dimensions=8, encoders=[e1, e2])
+model = DCCANOI(latent_dimensions=8, encoders=[e1, e2])
 ```
 
-### DCCA_SDL — Stochastic Decorrelation Loss
+### DCCASDL — Stochastic Decorrelation Loss
 
 Chang et al. 2018. Adds an explicit decorrelation term that penalises off-diagonal
 cross-covariance entries.
 
 ```python
-from cca_zoo.deep import DCCA_SDL
+from cca_zoo.deep import DCCASDL
 
-model = DCCA_SDL(latent_dimensions=8, encoders=[e1, e2])
+model = DCCASDL(latent_dimensions=8, encoders=[e1, e2])
 ```
 
 ### DCCAE — Deep CCA with Autoencoders

--- a/docs/user-guide/gam.md
+++ b/docs/user-guide/gam.md
@@ -11,7 +11,7 @@ by `cca_zoo`, rather than reimplemented from scratch.
 ## Background
 
 `GAMCCA` maximises the same unconstrained Eckart-Young (EY) objective used by the stochastic
-`*_EY` models in `cca_zoo.linear`, by `DCCA_EY` in `cca_zoo.deep`, and by `TreeCCA` in
+`*_EY` models in `cca_zoo.linear`, by `DCCAEY` in `cca_zoo.deep`, and by `TreeCCA` in
 `cca_zoo.tree` (the numpy-based models share the exact same implementation, in
 `cca_zoo._utils._ey`):
 
@@ -22,7 +22,7 @@ $$
 where, for embeddings $Z_i = f_i(X_i)$, $C$ is the mean pairwise cross-covariance (including
 $i = j$ terms) and $V$ the mean auto-covariance across all views. `GAMCCA` uses a generalized
 additive model — $f_i(x) = \sum_j s_j(x_j)$, one B-spline term per input feature — in place of a
-linear map (`CCA_EY`) or a boosted-tree ensemble (`TreeCCA`) as the function class for each
+linear map (`CCAEY`) or a boosted-tree ensemble (`TreeCCA`) as the function class for each
 $f_i$.
 
 Unlike those models, which reach the EY loss's optimum by many small (stochastic-)gradient steps,

--- a/docs/user-guide/gp.md
+++ b/docs/user-guide/gp.md
@@ -10,7 +10,7 @@ dependency: the kernel and its fit are built entirely from scikit-learn's own
 ## Background
 
 `GPCCA` maximises the same unconstrained Eckart-Young (EY) objective used by the stochastic
-`*_EY` models in `cca_zoo.linear`, by `DCCA_EY` in `cca_zoo.deep`, by `TreeCCA` in `cca_zoo.tree`,
+`*_EY` models in `cca_zoo.linear`, by `DCCAEY` in `cca_zoo.deep`, by `TreeCCA` in `cca_zoo.tree`,
 and by `GAMCCA` in `cca_zoo.gam` (all share the exact same implementation, in
 `cca_zoo._utils._ey`):
 

--- a/docs/user-guide/gp.md
+++ b/docs/user-guide/gp.md
@@ -1,6 +1,6 @@
 # GP Methods
 
-The `cca_zoo.gp` module provides `GPCCA`, a nonlinear multiview CCA method that uses a
+The `cca_zoo.gp` module provides `GaussianProcessCCA`, a nonlinear multiview CCA method that uses a
 Gaussian process with a joint (non-additive) kernel as the per-view encoder. It has no optional
 dependency: the kernel and its fit are built entirely from scikit-learn's own
 `GaussianProcessRegressor`, `RBF` and `ConstantKernel`, all already required by `cca_zoo`.
@@ -9,7 +9,7 @@ dependency: the kernel and its fit are built entirely from scikit-learn's own
 
 ## Background
 
-`GPCCA` maximises the same unconstrained Eckart-Young (EY) objective used by the stochastic
+`GaussianProcessCCA` maximises the same unconstrained Eckart-Young (EY) objective used by the stochastic
 `*_EY` models in `cca_zoo.linear`, by `DCCAEY` in `cca_zoo.deep`, by `TreeCCA` in `cca_zoo.tree`,
 and by `GAMCCA` in `cca_zoo.gam` (all share the exact same implementation, in
 `cca_zoo._utils._ey`):
@@ -21,12 +21,12 @@ $$
 where, for embeddings $Z_i = f_i(X_i)$, $C$ is the mean pairwise cross-covariance (including
 $i = j$ terms) and $V$ the mean auto-covariance across all views. Where `GAMCCA` sums one
 univariate B-spline term per input feature — additive, and so structurally unable to represent an
-interaction between two features of the same view — `GPCCA` fits a Gaussian process with an ARD
+interaction between two features of the same view — `GaussianProcessCCA` fits a Gaussian process with an ARD
 (per-feature-lengthscale) RBF kernel directly over each view's *raw, joint* feature vector: a
 genuine, non-additive function of all of that view's features at once. As a Bayesian model it
 also comes with calibrated predictive uncertainty for free.
 
-`GPCCA` is fit with the same inner/outer split as `GAMCCA`'s P-IRLS/GCV recipe, with the GP's own
+`GaussianProcessCCA` is fit with the same inner/outer split as `GAMCCA`'s P-IRLS/GCV recipe, with the GP's own
 machinery in place of `Ridge`/`RidgeCV`:
 
 1. **Inner loop — fixed-kernel Newton steps.** For the *current* kernel hyperparameters,
@@ -55,14 +55,14 @@ expect fitting to be markedly slower than `GAMCCA` or `TreeCCA` on large dataset
 ## Basic usage
 
 ```python
-from cca_zoo.gp import GPCCA
+from cca_zoo.gp import GaussianProcessCCA
 
-model = GPCCA(latent_dimensions=1).fit([X1, X2])
+model = GaussianProcessCCA(latent_dimensions=1).fit([X1, X2])
 z1, z2 = model.transform([X1, X2])
 corrs = model.score([X1, X2])
 
-# GPCCA also supports more than two views
-model3 = GPCCA(latent_dimensions=1).fit([X1, X2, X3])
+# GaussianProcessCCA also supports more than two views
+model3 = GaussianProcessCCA(latent_dimensions=1).fit([X1, X2, X3])
 ```
 
 ## Predictive uncertainty
@@ -78,7 +78,7 @@ means, stds = model.transform([X1, X2], return_std=True)
 standard deviation of view `i`'s latent component, propagated through the whitening transform —
 larger away from the training data, smaller near it, exactly as for any other GP posterior.
 
-`GPCCA` has no linear weight matrices and no per-feature decomposition analogous to `GAMCCA`'s
+`GaussianProcessCCA` has no linear weight matrices and no per-feature decomposition analogous to `GAMCCA`'s
 `shape_function` (the kernel is not additive across features), so `model.weights` raises
 `NotImplementedError`.
 
@@ -96,7 +96,7 @@ function of the $(n, m)$ and $(m, m)$ inducing-covariance matrices instead of th
 one, costing $O(n \, m^2 + m^3)$ instead of $O(n^3)$:
 
 ```python
-model = GPCCA(latent_dimensions=1, n_inducing=200).fit([X1, X2])  # X1, X2 have many samples
+model = GaussianProcessCCA(latent_dimensions=1, n_inducing=200).fit([X1, X2])  # X1, X2 have many samples
 ```
 
 Kernel hyperparameters are still selected by an *exact* marginal-likelihood fit — just on the
@@ -126,12 +126,12 @@ held-out canonical correlation.
 
 ## Practical notes
 
-- `GPCCA` supports 2 or more views.
+- `GaussianProcessCCA` supports 2 or more views.
 - `latent_dimensions` must not exceed the number of features in any view (the random-orthogonal
   initialisation draws that many orthogonal directions in feature space).
 - Exact GP inference (`n_inducing=None`) is $O(n^3)$ in the number of training samples; set
   `n_inducing` for datasets beyond a few thousand samples, or consider `GAMCCA` (if the
   relationship is additive) or `TreeCCA` instead.
 - No optional dependency is required (unlike `cca_zoo.tree`, which needs `xgboost`/`lightgbm`):
-  `GPCCA` is built entirely on `scikit-learn`'s `GaussianProcessRegressor`, `RBF`, `ConstantKernel`
+  `GaussianProcessCCA` is built entirely on `scikit-learn`'s `GaussianProcessRegressor`, `RBF`, `ConstantKernel`
   and `kmeans_plusplus`.

--- a/docs/user-guide/linear.md
+++ b/docs/user-guide/linear.md
@@ -170,16 +170,16 @@ All sparse methods in `cca_zoo.linear` use an **Alternating Least Squares (ALS)*
 Gram-Schmidt deflation to extract multiple canonical directions.
 
 !!! tip "Choosing a sparse method"
-    - **SCCA_PMD** — fast, interpretable L1 bound; good default for sparse CCA
-    - **SCCA_ADMM** — more principled L1 penalty via ADMM
-    - **SCCA_IPLS** — elastic net penalty; handles both L1 and L2 regularisation
+    - **SCCAPMD** — fast, interpretable L1 bound; good default for sparse CCA
+    - **SCCAADMM** — more principled L1 penalty via ADMM
+    - **SCCAIPLS** — elastic net penalty; handles both L1 and L2 regularisation
     - **ElasticCCA** — elastic net applied to the multiview sum-of-scores target
     - **ParkhomenkoCCA** — simple fixed soft-threshold; fast but less adaptive
     - **SCCASpan** — hard threshold (top-k entries); useful when sparsity level is known
     - **SAR** — penalty strength chosen automatically by BIC; no sparsity hyperparameter to tune
-    - **PLS_ALS** — no sparsity; ALS version of PLS (useful as a baseline)
+    - **PLSALS** — no sparsity; ALS version of PLS (useful as a baseline)
 
-### SCCA_PMD
+### SCCAPMD
 
 Imposes L1 constraints via bisection-based soft-thresholding (Witten 2009):
 
@@ -191,31 +191,31 @@ $$
 `tau=1` (default) gives no sparsity; smaller values give sparser solutions.
 
 ```python
-from cca_zoo.linear import SCCA_PMD
+from cca_zoo.linear import SCCAPMD
 
-model = SCCA_PMD(latent_dimensions=2, tau=0.5, random_state=0).fit([X1, X2])
+model = SCCAPMD(latent_dimensions=2, tau=0.5, random_state=0).fit([X1, X2])
 ```
 
-### SCCA_ADMM
+### SCCAADMM
 
 Solves the same L1-constrained problem via the Alternating Direction Method of Multipliers
 (Suo 2017). Often more precise than PMD for tight sparsity budgets.
 
 ```python
-from cca_zoo.linear import SCCA_ADMM
+from cca_zoo.linear import SCCAADMM
 
-model = SCCA_ADMM(latent_dimensions=2, tau=0.1, random_state=0).fit([X1, X2])
+model = SCCAADMM(latent_dimensions=2, tau=0.1, random_state=0).fit([X1, X2])
 ```
 
-### SCCA_IPLS
+### SCCAIPLS
 
 Uses an elastic net regression (sklearn) at each ALS step (Mai & Zhang 2019).
 `alpha` controls overall regularisation; `l1_ratio=1` gives Lasso, `l1_ratio=0` gives Ridge.
 
 ```python
-from cca_zoo.linear import SCCA_IPLS
+from cca_zoo.linear import SCCAIPLS
 
-model = SCCA_IPLS(latent_dimensions=2, alpha=0.01, l1_ratio=1.0, random_state=0).fit(
+model = SCCAIPLS(latent_dimensions=2, alpha=0.01, l1_ratio=1.0, random_state=0).fit(
     [X1, X2]
 )
 ```
@@ -271,15 +271,15 @@ from cca_zoo.linear import SAR
 model = SAR(latent_dimensions=2, random_state=0).fit([X1, X2])
 ```
 
-### PLS_ALS
+### PLSALS
 
 Standard ALS/power-iteration variant of PLS without regularisation. Useful as a baseline or
 when data are already low-dimensional.
 
 ```python
-from cca_zoo.linear import PLS_ALS
+from cca_zoo.linear import PLSALS
 
-model = PLS_ALS(latent_dimensions=2, random_state=0).fit([X1, X2])
+model = PLSALS(latent_dimensions=2, random_state=0).fit([X1, X2])
 ```
 
 ---
@@ -293,6 +293,6 @@ model = PLS_ALS(latent_dimensions=2, random_state=0).fit([X1, X2])
 | Maximise covariance, not correlation | `PLS` |
 | Three or more views | `MCCA` or `GCCA` |
 | Higher-order cross-view structure | `TCCA` |
-| Sparse weights needed | `SCCA_PMD` or `SCCA_IPLS` |
+| Sparse weights needed | `SCCAPMD` or `SCCAIPLS` |
 | Very large $p$ / streaming data | `CCAEY`, `PLSEY` |
 | Nonlinear relationships | See [Nonparametric Methods](nonparametric.md) |

--- a/docs/user-guide/linear.md
+++ b/docs/user-guide/linear.md
@@ -145,20 +145,20 @@ mini-batches.
 
 | Class | Description |
 |---|---|
-| `PLS_EY` | Eckart-Young PLS objective, stochastic updates |
-| `CCA_EY` | Eckart-Young CCA, stochastic updates, ridge-blended with `PLS_EY` via `c` |
-| `MCCA_EY` | Multiview EY-CCA for ≥2 views |
+| `PLSEY` | Eckart-Young PLS objective, stochastic updates |
+| `CCAEY` | Eckart-Young CCA, stochastic updates, ridge-blended with `PLSEY` via `c` |
+| `MCCAEY` | Multiview EY-CCA for ≥2 views |
 
-`CCA_EY`'s `c` parameter (default `0`) blends its loss towards `PLS_EY`'s (`c=1`) — in fact
-`PLS_EY` is implemented as `CCA_EY` with `c` fixed at `1`. Gradient descent on the raw,
+`CCAEY`'s `c` parameter (default `0`) blends its loss towards `PLSEY`'s (`c=1`) — in fact
+`PLSEY` is implemented as `CCAEY` with `c` fixed at `1`. Gradient descent on the raw,
 unregularised (`c=0`) objective can diverge when a mini-batch's samples don't outnumber the
 number of features by a healthy margin; if you see `nan` weights, increase `c` (0.1-0.3 is
 usually enough) or `batch_size`.
 
 ```python
-from cca_zoo.linear import CCA_EY
+from cca_zoo.linear import CCAEY
 
-model = CCA_EY(latent_dimensions=2, learning_rate=0.01, batch_size=128, max_iter=200)
+model = CCAEY(latent_dimensions=2, learning_rate=0.01, batch_size=128, max_iter=200)
 model.fit([X1, X2])
 ```
 
@@ -175,7 +175,7 @@ Gram-Schmidt deflation to extract multiple canonical directions.
     - **SCCA_IPLS** — elastic net penalty; handles both L1 and L2 regularisation
     - **ElasticCCA** — elastic net applied to the multiview sum-of-scores target
     - **ParkhomenkoCCA** — simple fixed soft-threshold; fast but less adaptive
-    - **SCCA_Span** — hard threshold (top-k entries); useful when sparsity level is known
+    - **SCCASpan** — hard threshold (top-k entries); useful when sparsity level is known
     - **SAR** — penalty strength chosen automatically by BIC; no sparsity hyperparameter to tune
     - **PLS_ALS** — no sparsity; ALS version of PLS (useful as a baseline)
 
@@ -244,7 +244,7 @@ from cca_zoo.linear import ParkhomenkoCCA
 model = ParkhomenkoCCA(latent_dimensions=2, tau=0.1, random_state=0).fit([X1, X2])
 ```
 
-### SCCA_Span
+### SCCASpan
 
 Hard-thresholding retaining only the top `span` entries, an ALS heuristic
 inspired by SpanCCA (Asteris 2016) rather than a reimplementation of its
@@ -252,9 +252,9 @@ own randomized low-rank sampling algorithm. Useful when the number of
 active features is known in advance.
 
 ```python
-from cca_zoo.linear import SCCA_Span
+from cca_zoo.linear import SCCASpan
 
-model = SCCA_Span(latent_dimensions=2, span=10, random_state=0).fit([X1, X2])
+model = SCCASpan(latent_dimensions=2, span=10, random_state=0).fit([X1, X2])
 ```
 
 ### SAR
@@ -294,5 +294,5 @@ model = PLS_ALS(latent_dimensions=2, random_state=0).fit([X1, X2])
 | Three or more views | `MCCA` or `GCCA` |
 | Higher-order cross-view structure | `TCCA` |
 | Sparse weights needed | `SCCA_PMD` or `SCCA_IPLS` |
-| Very large $p$ / streaming data | `CCA_EY`, `PLS_EY` |
+| Very large $p$ / streaming data | `CCAEY`, `PLSEY` |
 | Nonlinear relationships | See [Nonparametric Methods](nonparametric.md) |

--- a/docs/user-guide/nonparametric.md
+++ b/docs/user-guide/nonparametric.md
@@ -165,6 +165,6 @@ model = KCCA(
 
 - Kernel methods store the full $n \times n$ kernel matrices. Memory is $O(n^2)$; be cautious
   with $n > 10{,}000$.
-- For large datasets, prefer the linear stochastic methods (`CCA_EY`, `PLS_EY`) or deep methods.
+- For large datasets, prefer the linear stochastic methods (`CCAEY`, `PLSEY`) or deep methods.
 - The `c` parameter is crucial: too small → numerical instability; too large → loss of structure.
   Use cross-validation (see [Model Selection](model-selection.md)).

--- a/docs/user-guide/tree.md
+++ b/docs/user-guide/tree.md
@@ -14,7 +14,7 @@ pip install cca-zoo[tree]
 ## Background
 
 `TreeCCA` maximises the same unconstrained Eckart-Young (EY) objective used by the stochastic
-`*_EY` models in `cca_zoo.linear` and by `DCCA_EY` in `cca_zoo.deep` (the numpy-based models
+`*_EY` models in `cca_zoo.linear` and by `DCCAEY` in `cca_zoo.deep` (the numpy-based models
 share the exact same implementation, in `cca_zoo._utils._ey`):
 
 $$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ select = ["E", "F", "I", "UP", "ANN", "N", "D"]
 ignore = [
     "D203", "D212",
     # Scientific naming conventions: uppercase matrices (A, B, W, X, U, V, K, Q, T)
-    "N801",  # class names like rCCA, SCCA_PMD, PLS_ALS are intentional
+    "N801",  # rCCA's lowercase start, and the deprecated *_EY/*_PMD/etc. aliases
     "N802",  # function names like _build_A, _build_B
     "N803",  # argument names like X, W, A
     "N806",  # variable names like A, B, W, U, V, K, T

--- a/tests/gp/test_gpcca.py
+++ b/tests/gp/test_gpcca.py
@@ -239,14 +239,14 @@ def test_encoder_models_are_sklearn_gaussian_process_regressor(
 def test_gpcca_finds_correlation_on_correlated_views(
     correlated_views: list[np.ndarray],
 ) -> None:
-    """GaussianProcessCCA finds substantial correlation on views with shared latent structure."""
+    """GaussianProcessCCA finds substantial correlation on shared latent structure."""
     model = GaussianProcessCCA(latent_dimensions=1, random_state=0)
     s = model.fit(correlated_views).score(correlated_views)
     assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
 
 
 def test_gpcca_finds_correlation_on_three_correlated_views() -> None:
-    """GaussianProcessCCA (multiview) finds substantial correlation on 3 correlated views."""
+    """GaussianProcessCCA (multiview) finds substantial correlation on 3 views."""
     rng = np.random.default_rng(0)
     z = rng.standard_normal((200, 1))
     views = [
@@ -306,14 +306,16 @@ def test_sparse_finds_correlation_on_correlated_views(
 ) -> None:
     """The sparse approximation still recovers substantial correlation."""
     n = correlated_views[0].shape[0]
-    model = GaussianProcessCCA(latent_dimensions=1, random_state=0, n_inducing=max(10, n // 3))
+    model = GaussianProcessCCA(
+        latent_dimensions=1, random_state=0, n_inducing=max(10, n // 3)
+    )
     s = model.fit(correlated_views).score(correlated_views)
     assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
 
 
 @pytest.mark.slow
 def test_sparse_scales_to_large_sample_sizes() -> None:
-    """Sparse GaussianProcessCCA fits at a sample size that would defeat exact GP inference.
+    """Sparse GaussianProcessCCA fits at a size that would defeat exact GP inference.
 
     Exact GP inference redoes an O(n^3) Cholesky factorisation at every
     Newton step of every inner/outer round, which would be impractically
@@ -338,7 +340,7 @@ def test_sparse_scales_to_large_sample_sizes() -> None:
 
 @pytest.mark.slow
 def test_gpcca_outperforms_others_on_genuine_interaction() -> None:
-    """GaussianProcessCCA beats GAMCCA, TreeCCA, and rCCA on a genuine feature-interaction task.
+    """GaussianProcessCCA beats GAMCCA, TreeCCA, and rCCA on a feature-interaction task.
 
     View 1 is two noisy independent factors ``u, v``; view 2 is a noisy
     copy of their *interaction* ``u * v`` -- not additively separable into
@@ -346,8 +348,8 @@ def test_gpcca_outperforms_others_on_genuine_interaction() -> None:
     encoder structurally cannot represent this; ``TreeCCA`` can only
     approximate it via multivariate splits, and at its default
     ``colsample_bytree`` a single tree is often starved of joint access to
-    both features. GaussianProcessCCA's joint (non-additive) RBF kernel represents the
-    interaction directly.
+    both features. GaussianProcessCCA's joint (non-additive) RBF kernel
+    represents the interaction directly.
 
     Marked slow since it also requires TreeCCA's optional ``xgboost``
     dependency, not part of the base ``dev`` install.
@@ -382,7 +384,9 @@ def test_gpcca_outperforms_others_on_genuine_interaction() -> None:
     rcca = rCCA(latent_dimensions=1, c=[0.3, 0.3])
     rcca_test = rcca.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
 
-    assert gp_test > 0.7, f"Expected GaussianProcessCCA to recover the interaction, got {gp_test}"
+    assert gp_test > 0.7, (
+        f"Expected GaussianProcessCCA to recover the interaction, got {gp_test}"
+    )
     assert gp_test > gam_test + 0.05, (
         f"Expected GaussianProcessCCA ({gp_test}) to beat additive GAMCCA ({gam_test}) "
         f"on a genuine feature interaction"
@@ -392,5 +396,6 @@ def test_gpcca_outperforms_others_on_genuine_interaction() -> None:
         f"TreeCCA's default colsample_bytree"
     )
     assert gp_test > rcca_test + 0.3, (
-        f"Expected GaussianProcessCCA ({gp_test}) to clearly beat linear rCCA ({rcca_test})"
+        f"Expected GaussianProcessCCA ({gp_test}) to clearly beat linear "
+        f"rCCA ({rcca_test})"
     )

--- a/tests/gp/test_gpcca.py
+++ b/tests/gp/test_gpcca.py
@@ -1,6 +1,6 @@
-"""Tests for GPCCA.
+"""Tests for GaussianProcessCCA.
 
-Like GAMCCA, GPCCA has no optional dependency (it is built entirely on
+Like GAMCCA, GaussianProcessCCA has no optional dependency (it is built entirely on
 scikit-learn's GaussianProcessRegressor, already required by cca_zoo), so
 these tests run unconditionally.
 """
@@ -11,12 +11,12 @@ import numpy as np
 import pytest
 from sklearn.gaussian_process import GaussianProcessRegressor
 
-from cca_zoo.gp import GPCCA
+from cca_zoo.gp import GaussianProcessCCA
 from cca_zoo.gp._gpcca import _GpEncoder, _SparseGpEncoder
 
 
-def _make_model(latent_dimensions: int = 1, **kwargs: object) -> GPCCA:
-    return GPCCA(latent_dimensions=latent_dimensions, **kwargs)
+def _make_model(latent_dimensions: int = 1, **kwargs: object) -> GaussianProcessCCA:
+    return GaussianProcessCCA(latent_dimensions=latent_dimensions, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -136,7 +136,7 @@ def test_score_values_in_range(two_views_small: list[np.ndarray]) -> None:
 
 
 # get_params/set_params roundtrip behaviour is exercised generically for
-# every model in the package (including GPCCA) by
+# every model in the package (including GaussianProcessCCA) by
 # tests/test_sklearn_compat.py.
 
 
@@ -149,7 +149,7 @@ def test_weights_not_fitted_raises() -> None:
     """Accessing weights before fitting raises NotFittedError."""
     from sklearn.exceptions import NotFittedError
 
-    model = GPCCA()
+    model = GaussianProcessCCA()
     with pytest.raises(NotFittedError):
         _ = model.weights
 
@@ -195,7 +195,7 @@ def test_pairwise_correlations_shape(two_views_small: list[np.ndarray]) -> None:
 
 
 def test_center_false(two_views_small: list[np.ndarray]) -> None:
-    """GPCCA works with center=False."""
+    """GaussianProcessCCA works with center=False."""
     model = _make_model(center=False)
     model.fit(two_views_small)
     result = model.transform(two_views_small)
@@ -239,21 +239,21 @@ def test_encoder_models_are_sklearn_gaussian_process_regressor(
 def test_gpcca_finds_correlation_on_correlated_views(
     correlated_views: list[np.ndarray],
 ) -> None:
-    """GPCCA finds substantial correlation on views with shared latent structure."""
-    model = GPCCA(latent_dimensions=1, random_state=0)
+    """GaussianProcessCCA finds substantial correlation on views with shared latent structure."""
+    model = GaussianProcessCCA(latent_dimensions=1, random_state=0)
     s = model.fit(correlated_views).score(correlated_views)
     assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
 
 
 def test_gpcca_finds_correlation_on_three_correlated_views() -> None:
-    """GPCCA (multiview) finds substantial correlation on 3 correlated views."""
+    """GaussianProcessCCA (multiview) finds substantial correlation on 3 correlated views."""
     rng = np.random.default_rng(0)
     z = rng.standard_normal((200, 1))
     views = [
         z @ rng.standard_normal((1, 5)) + 0.1 * rng.standard_normal((200, 5))
         for _ in range(3)
     ]
-    model = GPCCA(latent_dimensions=1, random_state=0)
+    model = GaussianProcessCCA(latent_dimensions=1, random_state=0)
     s = model.fit(views).score(views)
     assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
 
@@ -306,14 +306,14 @@ def test_sparse_finds_correlation_on_correlated_views(
 ) -> None:
     """The sparse approximation still recovers substantial correlation."""
     n = correlated_views[0].shape[0]
-    model = GPCCA(latent_dimensions=1, random_state=0, n_inducing=max(10, n // 3))
+    model = GaussianProcessCCA(latent_dimensions=1, random_state=0, n_inducing=max(10, n // 3))
     s = model.fit(correlated_views).score(correlated_views)
     assert np.all(s > 0.5), f"Expected substantial correlation, got {s}"
 
 
 @pytest.mark.slow
 def test_sparse_scales_to_large_sample_sizes() -> None:
-    """Sparse GPCCA fits at a sample size that would defeat exact GP inference.
+    """Sparse GaussianProcessCCA fits at a sample size that would defeat exact GP inference.
 
     Exact GP inference redoes an O(n^3) Cholesky factorisation at every
     Newton step of every inner/outer round, which would be impractically
@@ -329,7 +329,7 @@ def test_sparse_scales_to_large_sample_sizes() -> None:
     X1_tr, X1_te = X1[:n_train], X1[n_train:]
     X2_tr, X2_te = X2[:n_train], X2[n_train:]
 
-    model = GPCCA(latent_dimensions=1, random_state=0, n_inducing=100)
+    model = GaussianProcessCCA(latent_dimensions=1, random_state=0, n_inducing=100)
     test_corr = model.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
     assert test_corr > 0.7, (
         f"Expected substantial held-out correlation, got {test_corr}"
@@ -338,7 +338,7 @@ def test_sparse_scales_to_large_sample_sizes() -> None:
 
 @pytest.mark.slow
 def test_gpcca_outperforms_others_on_genuine_interaction() -> None:
-    """GPCCA beats GAMCCA, TreeCCA, and rCCA on a genuine feature-interaction task.
+    """GaussianProcessCCA beats GAMCCA, TreeCCA, and rCCA on a genuine feature-interaction task.
 
     View 1 is two noisy independent factors ``u, v``; view 2 is a noisy
     copy of their *interaction* ``u * v`` -- not additively separable into
@@ -346,7 +346,7 @@ def test_gpcca_outperforms_others_on_genuine_interaction() -> None:
     encoder structurally cannot represent this; ``TreeCCA`` can only
     approximate it via multivariate splits, and at its default
     ``colsample_bytree`` a single tree is often starved of joint access to
-    both features. GPCCA's joint (non-additive) RBF kernel represents the
+    both features. GaussianProcessCCA's joint (non-additive) RBF kernel represents the
     interaction directly.
 
     Marked slow since it also requires TreeCCA's optional ``xgboost``
@@ -370,7 +370,7 @@ def test_gpcca_outperforms_others_on_genuine_interaction() -> None:
     X1_tr, X1_te = X1[:n_train], X1[n_train:]
     X2_tr, X2_te = X2[:n_train], X2[n_train:]
 
-    gp = GPCCA(latent_dimensions=1, random_state=0)
+    gp = GaussianProcessCCA(latent_dimensions=1, random_state=0)
     gp_test = gp.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
 
     gam = GAMCCA(latent_dimensions=1, random_state=0)
@@ -382,15 +382,15 @@ def test_gpcca_outperforms_others_on_genuine_interaction() -> None:
     rcca = rCCA(latent_dimensions=1, c=[0.3, 0.3])
     rcca_test = rcca.fit([X1_tr, X2_tr]).score([X1_te, X2_te])[0]
 
-    assert gp_test > 0.7, f"Expected GPCCA to recover the interaction, got {gp_test}"
+    assert gp_test > 0.7, f"Expected GaussianProcessCCA to recover the interaction, got {gp_test}"
     assert gp_test > gam_test + 0.05, (
-        f"Expected GPCCA ({gp_test}) to beat additive GAMCCA ({gam_test}) "
+        f"Expected GaussianProcessCCA ({gp_test}) to beat additive GAMCCA ({gam_test}) "
         f"on a genuine feature interaction"
     )
     assert gp_test > tree_test + 0.05, (
-        f"Expected GPCCA ({gp_test}) to beat TreeCCA ({tree_test}) at "
+        f"Expected GaussianProcessCCA ({gp_test}) to beat TreeCCA ({tree_test}) at "
         f"TreeCCA's default colsample_bytree"
     )
     assert gp_test > rcca_test + 0.3, (
-        f"Expected GPCCA ({gp_test}) to clearly beat linear rCCA ({rcca_test})"
+        f"Expected GaussianProcessCCA ({gp_test}) to clearly beat linear rCCA ({rcca_test})"
     )

--- a/tests/linear/test_gradient.py
+++ b/tests/linear/test_gradient.py
@@ -1,14 +1,14 @@
-"""Tests for gradient-descent CCA variants: PLS_EY, CCA_EY, MCCA_EY."""
+"""Tests for gradient-descent CCA variants: PLSEY, CCAEY, MCCAEY."""
 
 from __future__ import annotations
 
 import numpy as np
 import pytest
 
-from cca_zoo.linear import CCA, CCA_EY, MCCA, MCCA_EY, PLS, PLS_EY
+from cca_zoo.linear import CCA, CCAEY, MCCA, MCCAEY, PLS, PLSEY
 
-GRADIENT_MODELS_TWO_VIEW = [PLS_EY, CCA_EY]
-GRADIENT_MODELS_MULTI_VIEW = [MCCA_EY]
+GRADIENT_MODELS_TWO_VIEW = [PLSEY, CCAEY]
+GRADIENT_MODELS_MULTI_VIEW = [MCCAEY]
 ALL_GRADIENT_MODELS = GRADIENT_MODELS_TWO_VIEW + GRADIENT_MODELS_MULTI_VIEW
 
 # Use fewer iterations for speed in tests
@@ -17,7 +17,7 @@ _FIT_KWARGS: dict = dict(latent_dimensions=1, max_iter=50, random_state=0)
 
 @pytest.fixture
 def three_correlated_views() -> list[np.ndarray]:
-    """Three views sharing a latent structure, for MCCA_EY correctness checks."""
+    """Three views sharing a latent structure, for MCCAEY correctness checks."""
     rng = np.random.default_rng(0)
     z = rng.standard_normal((300, 2))
     x1 = z @ rng.standard_normal((2, 10)) + 0.1 * rng.standard_normal((300, 10))
@@ -53,7 +53,7 @@ def test_two_view_fit_completes_all(
 def test_three_view_fit_completes(
     ModelClass: type, three_views: list[np.ndarray]
 ) -> None:
-    """MCCA_EY fits on three-view data."""
+    """MCCAEY fits on three-view data."""
     model = ModelClass(**_FIT_KWARGS)
     fitted = model.fit(three_views)
     assert fitted is model
@@ -81,7 +81,7 @@ def test_transform_shapes_two_view(
 def test_transform_shapes_multi_view(
     ModelClass: type, three_views: list[np.ndarray]
 ) -> None:
-    """MCCA_EY transform returns correct shapes for three views."""
+    """MCCAEY transform returns correct shapes for three views."""
     k = 2
     model = ModelClass(latent_dimensions=k, max_iter=50, random_state=0).fit(
         three_views
@@ -233,22 +233,22 @@ def test_different_seeds_give_different_results(
 
 
 # ---------------------------------------------------------------------------
-# No upfront whitening (regression: CCA_EY used to whiten the full dataset
+# No upfront whitening (regression: CCAEY used to whiten the full dataset
 # with a full-batch SVD before any gradient step, defeating the entire
-# point of a mini-batch/streaming stochastic method; MCCA_EY inherited the
-# same bug via CCA_EY.fit(). PLS_EY, TreeCCA, and DCCA_EY all apply the same
+# point of a mini-batch/streaming stochastic method; MCCAEY inherited the
+# same bug via CCAEY.fit(). PLSEY, TreeCCA, and DCCAEY all apply the same
 # shared EY loss directly to raw embeddings with no such step, and the
 # family's own docs describe it as needing no full-batch preprocessing.)
 #
-# CCA_EY keeps a ``c`` ridge parameter that continuously blends its loss
-# towards PLS_EY's (see cca_zoo._utils._ey.weight_gram_mean); PLS_EY is
-# implemented as a thin CCA_EY subclass with ``c`` fixed at 1, mirroring how
+# CCAEY keeps a ``c`` ridge parameter that continuously blends its loss
+# towards PLSEY's (see cca_zoo._utils._ey.weight_gram_mean); PLSEY is
+# implemented as a thin CCAEY subclass with ``c`` fixed at 1, mirroring how
 # CCA/PLS are thin rCCA subclasses with ``c`` fixed at 0/1.
 # ---------------------------------------------------------------------------
 
 
 def test_cca_ey_module_does_not_reference_svd_whiten() -> None:
-    """CCA_EY's source no longer calls the full-batch whitening routine."""
+    """CCAEY's source no longer calls the full-batch whitening routine."""
     import inspect
 
     from cca_zoo.linear.gradient import _cca_ey
@@ -258,17 +258,17 @@ def test_cca_ey_module_does_not_reference_svd_whiten() -> None:
 
 
 def test_cca_ey_accepts_c_pls_ey_does_not() -> None:
-    """C blends CCA_EY towards PLS_EY; PLS_EY fixes it at 1, unexposed."""
-    assert CCA_EY().get_params()["c"] == 0.0
-    assert "c" not in PLS_EY().get_params()
+    """C blends CCAEY towards PLSEY; PLSEY fixes it at 1, unexposed."""
+    assert CCAEY().get_params()["c"] == 0.0
+    assert "c" not in PLSEY().get_params()
 
 
 def test_pls_ey_loss_matches_cca_ey_at_c_equal_one(
     two_views: list[np.ndarray],
 ) -> None:
-    """PLS_EY's derivative/objective are exactly CCA_EY's own formula at c=1.
+    """PLSEY's derivative/objective are exactly CCAEY's own formula at c=1.
 
-    PLS_EY no longer fits identical weights to CCA_EY(c=1) given the same
+    PLSEY no longer fits identical weights to CCAEY(c=1) given the same
     seed, since the two now deliberately use different initial-weights
     strategies (see cca_zoo._utils._ey.random_orthonormal_weights vs.
     cheap_orthonormal_projection_weights) -- this checks the invariant that
@@ -278,8 +278,8 @@ def test_pls_ey_loss_matches_cca_ey_at_c_equal_one(
     rng = np.random.default_rng(0)
     weights = [rng.standard_normal((v.shape[1], k)) for v in two_views]
     representations = [v @ w for v, w in zip(two_views, weights)]
-    pls = PLS_EY(latent_dimensions=k)
-    cca_c1 = CCA_EY(latent_dimensions=k, c=1.0)
+    pls = PLSEY(latent_dimensions=k)
+    cca_c1 = CCAEY(latent_dimensions=k, c=1.0)
     grads_pls = pls._derivative(two_views, representations, weights)
     grads_cca = cca_c1._derivative(two_views, representations, weights)
     for a, b in zip(grads_pls, grads_cca):
@@ -296,7 +296,7 @@ def test_cca_ey_c_zero_matches_shared_ey_gradient(
     from cca_zoo._utils._ey import ey_grad_z
 
     k = 2
-    model = CCA_EY(latent_dimensions=k, c=0.0, random_state=0)
+    model = CCAEY(latent_dimensions=k, c=0.0, random_state=0)
     views_ = model._setup_fit(two_views)
     rng = np.random.default_rng(0)
     weights = [rng.standard_normal((v.shape[1], k)) for v in views_]
@@ -335,11 +335,11 @@ def test_center_false(ModelClass: type, two_views: list[np.ndarray]) -> None:
 
 
 def test_cca_ey_matches_cca(correlated_views: list[np.ndarray]) -> None:
-    """Converged CCA_EY recovers the same correlations as exact CCA."""
+    """Converged CCAEY recovers the same correlations as exact CCA."""
     k = 2
     s_cca = CCA(latent_dimensions=k).fit(correlated_views).score(correlated_views)
     s_ey = (
-        CCA_EY(latent_dimensions=k, max_iter=1000, random_state=0)
+        CCAEY(latent_dimensions=k, max_iter=1000, random_state=0)
         .fit(correlated_views)
         .score(correlated_views)
     )
@@ -351,11 +351,11 @@ def test_cca_ey_matches_cca(correlated_views: list[np.ndarray]) -> None:
 
 
 def test_pls_ey_matches_pls(correlated_views: list[np.ndarray]) -> None:
-    """Converged PLS_EY recovers the same correlations as exact PLS."""
+    """Converged PLSEY recovers the same correlations as exact PLS."""
     k = 2
     s_pls = PLS(latent_dimensions=k).fit(correlated_views).score(correlated_views)
     s_ey = (
-        PLS_EY(latent_dimensions=k, max_iter=1000, random_state=0)
+        PLSEY(latent_dimensions=k, max_iter=1000, random_state=0)
         .fit(correlated_views)
         .score(correlated_views)
     )
@@ -365,7 +365,7 @@ def test_pls_ey_matches_pls(correlated_views: list[np.ndarray]) -> None:
 
 
 def test_mcca_ey_matches_mcca(three_correlated_views: list[np.ndarray]) -> None:
-    """Converged MCCA_EY recovers the same correlations as exact MCCA."""
+    """Converged MCCAEY recovers the same correlations as exact MCCA."""
     k = 2
     s_mcca = (
         MCCA(latent_dimensions=k)
@@ -373,7 +373,7 @@ def test_mcca_ey_matches_mcca(three_correlated_views: list[np.ndarray]) -> None:
         .score(three_correlated_views)
     )
     s_ey = (
-        MCCA_EY(latent_dimensions=k, max_iter=1000, random_state=0)
+        MCCAEY(latent_dimensions=k, max_iter=1000, random_state=0)
         .fit(three_correlated_views)
         .score(three_correlated_views)
     )
@@ -396,20 +396,20 @@ def test_gradient_models_find_high_correlation(
 
 
 # ---------------------------------------------------------------------------
-# Initial weights: PLS_EY gets plain orthonormal weights (matching its own
-# weight-space penalty); CCA_EY (and MCCA_EY, which inherits it) gets a
+# Initial weights: PLSEY gets plain orthonormal weights (matching its own
+# weight-space penalty); CCAEY (and MCCAEY, which inherits it) gets a
 # cheap, data-informed init giving exactly unit-variance, uncorrelated
 # projections on the first mini-batch instead (a cheap stand-in for
 # classical CCA's full whitening step, and a direct counter to the
-# near-null-direction divergence risk noted in CCA_EY's own docstring).
+# near-null-direction divergence risk noted in CCAEY's own docstring).
 # ---------------------------------------------------------------------------
 
 
 def test_pls_ey_initial_weights_are_orthonormal(two_views: list[np.ndarray]) -> None:
-    """PLS_EY's initial weights have exactly orthonormal columns per view."""
+    """PLSEY's initial weights have exactly orthonormal columns per view."""
     k = 2
     rng = np.random.default_rng(0)
-    model = PLS_EY(latent_dimensions=k, random_state=0)
+    model = PLSEY(latent_dimensions=k, random_state=0)
     weights = model._initial_weights(two_views, rng)
     for w in weights:
         np.testing.assert_allclose(w.T @ w, np.eye(k), atol=1e-10)
@@ -418,16 +418,16 @@ def test_pls_ey_initial_weights_are_orthonormal(two_views: list[np.ndarray]) -> 
 def test_cca_ey_initial_weights_give_orthonormal_projections(
     two_views: list[np.ndarray],
 ) -> None:
-    """CCA_EY's initial weights give unit-variance, uncorrelated projections.
+    """CCAEY's initial weights give unit-variance, uncorrelated projections.
 
-    Unlike PLS_EY's plain weight-orthonormal init, CCA_EY's own initial
+    Unlike PLSEY's plain weight-orthonormal init, CCAEY's own initial
     *weights* are not themselves orthonormal in general -- what's
     orthonormal is the projection onto the mini-batch used to build them.
     """
     k = 2
     bs = 16
     rng = np.random.default_rng(0)
-    model = CCA_EY(latent_dimensions=k, batch_size=bs, random_state=0)
+    model = CCAEY(latent_dimensions=k, batch_size=bs, random_state=0)
     weights = model._initial_weights(two_views, rng)
     # Re-derive, with a fresh rng in the same state, exactly which rows the
     # initialiser sampled, so the projection can be checked on that batch.
@@ -446,19 +446,19 @@ def test_cca_ey_initial_weights_differ_from_pls_ey(
     k = 2
     rng_pls = np.random.default_rng(0)
     rng_cca = np.random.default_rng(0)
-    w_pls = PLS_EY(latent_dimensions=k)._initial_weights(two_views, rng_pls)
-    w_cca = CCA_EY(latent_dimensions=k)._initial_weights(two_views, rng_cca)
+    w_pls = PLSEY(latent_dimensions=k)._initial_weights(two_views, rng_pls)
+    w_cca = CCAEY(latent_dimensions=k)._initial_weights(two_views, rng_cca)
     assert any(not np.allclose(a, b) for a, b in zip(w_pls, w_cca))
 
 
 def test_mcca_ey_initial_weights_give_orthonormal_projections(
     three_correlated_views: list[np.ndarray],
 ) -> None:
-    """MCCA_EY inherits CCA_EY's data-informed initialiser unchanged."""
+    """MCCAEY inherits CCAEY's data-informed initialiser unchanged."""
     k = 2
     bs = 32
     rng = np.random.default_rng(0)
-    model = MCCA_EY(latent_dimensions=k, batch_size=bs, random_state=0)
+    model = MCCAEY(latent_dimensions=k, batch_size=bs, random_state=0)
     weights = model._initial_weights(three_correlated_views, rng)
     rng2 = np.random.default_rng(0)
     n = three_correlated_views[0].shape[0]

--- a/tests/linear/test_iterative.py
+++ b/tests/linear/test_iterative.py
@@ -226,9 +226,9 @@ def test_scca_pmd_tau_controls_sparsity_monotonically(
     taus = [0.3, 0.5, 0.7, 1.0]
     nnz_by_tau = []
     for tau in taus:
-        model = SCCAPMD(
-            latent_dimensions=1, tau=tau, max_iter=200, random_state=0
-        ).fit(two_views)
+        model = SCCAPMD(latent_dimensions=1, tau=tau, max_iter=200, random_state=0).fit(
+            two_views
+        )
         nnz_by_tau.append(sum(int(np.sum(np.abs(w) > 1e-10)) for w in model.weights))
     assert nnz_by_tau == sorted(nnz_by_tau), (
         f"nnz should be non-decreasing in tau, got {dict(zip(taus, nnz_by_tau))}"

--- a/tests/linear/test_iterative.py
+++ b/tests/linear/test_iterative.py
@@ -1,6 +1,6 @@
 """Tests for ALS-based sparse/regularised CCA variants.
 
-Covers PLS_ALS, SCCA_PMD, SCCA_ADMM, SCCA_IPLS, SCCA_Span, ElasticCCA,
+Covers PLS_ALS, SCCA_PMD, SCCA_ADMM, SCCA_IPLS, SCCASpan, ElasticCCA,
 ParkhomenkoCCA, SAR.
 """
 
@@ -17,7 +17,7 @@ from cca_zoo.linear import (
     SCCA_PMD,
     ElasticCCA,
     ParkhomenkoCCA,
-    SCCA_Span,
+    SCCASpan,
 )
 
 ALL_ITERATIVE_MODELS = [
@@ -25,7 +25,7 @@ ALL_ITERATIVE_MODELS = [
     SCCA_PMD,
     SCCA_ADMM,
     SCCA_IPLS,
-    SCCA_Span,
+    SCCASpan,
     ElasticCCA,
     ParkhomenkoCCA,
     SAR,
@@ -246,10 +246,10 @@ def test_parkhomenko_achieves_sparsity(two_views: list[np.ndarray]) -> None:
 
 
 def test_scca_span_achieves_sparsity(two_views: list[np.ndarray]) -> None:
-    """SCCA_Span with span < n_features produces sparse weights."""
+    """SCCASpan with span < n_features produces sparse weights."""
     n_features = two_views[0].shape[1]
     span = n_features // 2
-    model = SCCA_Span(latent_dimensions=1, span=span, max_iter=200, random_state=0).fit(
+    model = SCCASpan(latent_dimensions=1, span=span, max_iter=200, random_state=0).fit(
         two_views
     )
     # First view should have at most 'span' nonzero entries per dimension

--- a/tests/linear/test_iterative.py
+++ b/tests/linear/test_iterative.py
@@ -1,6 +1,6 @@
 """Tests for ALS-based sparse/regularised CCA variants.
 
-Covers PLS_ALS, SCCA_PMD, SCCA_ADMM, SCCA_IPLS, SCCASpan, ElasticCCA,
+Covers PLSALS, SCCAPMD, SCCAADMM, SCCAIPLS, SCCASpan, ElasticCCA,
 ParkhomenkoCCA, SAR.
 """
 
@@ -10,21 +10,21 @@ import numpy as np
 import pytest
 
 from cca_zoo.linear import (
-    PLS_ALS,
+    PLSALS,
     SAR,
-    SCCA_ADMM,
-    SCCA_IPLS,
-    SCCA_PMD,
+    SCCAADMM,
+    SCCAIPLS,
+    SCCAPMD,
     ElasticCCA,
     ParkhomenkoCCA,
     SCCASpan,
 )
 
 ALL_ITERATIVE_MODELS = [
-    PLS_ALS,
-    SCCA_PMD,
-    SCCA_ADMM,
-    SCCA_IPLS,
+    PLSALS,
+    SCCAPMD,
+    SCCAADMM,
+    SCCAIPLS,
     SCCASpan,
     ElasticCCA,
     ParkhomenkoCCA,
@@ -179,8 +179,8 @@ def test_get_factor_loadings_shapes(
 
 
 def test_scca_pmd_achieves_sparsity(two_views: list[np.ndarray]) -> None:
-    """SCCA_PMD with small tau produces sparse weights (some zeros)."""
-    model = SCCA_PMD(latent_dimensions=1, tau=0.3, max_iter=200, random_state=0).fit(
+    """SCCAPMD with small tau produces sparse weights (some zeros)."""
+    model = SCCAPMD(latent_dimensions=1, tau=0.3, max_iter=200, random_state=0).fit(
         two_views
     )
     for w in model.weights:
@@ -189,7 +189,7 @@ def test_scca_pmd_achieves_sparsity(two_views: list[np.ndarray]) -> None:
 
 
 def test_scca_pmd_invariant_to_input_scale(two_views: list[np.ndarray]) -> None:
-    """SCCA_PMD's fitted weights (up to sign) must not depend on the
+    """SCCAPMD's fitted weights (up to sign) must not depend on the
     overall scale of the input data -- tau is the only sparsity control.
 
     Regression test: _bisect_threshold used to compare the *unnormalised*
@@ -201,10 +201,10 @@ def test_scca_pmd_invariant_to_input_scale(two_views: list[np.ndarray]) -> None:
     "no constraint") still producing near-total sparsity.
     """
     scaled_views = [v * 37.0 for v in two_views]
-    model_a = SCCA_PMD(latent_dimensions=1, tau=0.5, max_iter=200, random_state=0).fit(
+    model_a = SCCAPMD(latent_dimensions=1, tau=0.5, max_iter=200, random_state=0).fit(
         two_views
     )
-    model_b = SCCA_PMD(latent_dimensions=1, tau=0.5, max_iter=200, random_state=0).fit(
+    model_b = SCCAPMD(latent_dimensions=1, tau=0.5, max_iter=200, random_state=0).fit(
         scaled_views
     )
     for w_a, w_b in zip(model_a.weights, model_b.weights):
@@ -223,7 +223,7 @@ def test_scca_pmd_tau_controls_sparsity_monotonically(
     taus = [0.3, 0.5, 0.7, 1.0]
     nnz_by_tau = []
     for tau in taus:
-        model = SCCA_PMD(
+        model = SCCAPMD(
             latent_dimensions=1, tau=tau, max_iter=200, random_state=0
         ).fit(two_views)
         nnz_by_tau.append(sum(int(np.sum(np.abs(w) > 1e-10)) for w in model.weights))
@@ -259,8 +259,8 @@ def test_scca_span_achieves_sparsity(two_views: list[np.ndarray]) -> None:
 
 
 def test_scca_admm_achieves_sparsity(two_views: list[np.ndarray]) -> None:
-    """SCCA_ADMM with positive tau produces some sparse weights."""
-    model = SCCA_ADMM(latent_dimensions=1, tau=0.5, max_iter=200, random_state=0).fit(
+    """SCCAADMM with positive tau produces some sparse weights."""
+    model = SCCAADMM(latent_dimensions=1, tau=0.5, max_iter=200, random_state=0).fit(
         two_views
     )
     assert hasattr(model, "weights_")
@@ -277,8 +277,8 @@ def test_elastic_cca_with_lasso(two_views: list[np.ndarray]) -> None:
 
 
 def test_scca_ipls_with_lasso(two_views: list[np.ndarray]) -> None:
-    """SCCA_IPLS with alpha > 0 runs without error."""
-    model = SCCA_IPLS(
+    """SCCAIPLS with alpha > 0 runs without error."""
+    model = SCCAIPLS(
         latent_dimensions=1, alpha=0.1, l1_ratio=1.0, max_iter=100, random_state=0
     ).fit(two_views)
     assert hasattr(model, "weights_")
@@ -408,13 +408,13 @@ def test_pairwise_correlations_shape(
 
 
 def test_pls_als_matches_pls(correlated_views: list[np.ndarray]) -> None:
-    """PLS_ALS (converged) recovers the same correlations as exact PLS."""
+    """PLSALS (converged) recovers the same correlations as exact PLS."""
     from cca_zoo.linear import PLS
 
     k = 2
     s_pls = PLS(latent_dimensions=k).fit(correlated_views).score(correlated_views)
     s_als = (
-        PLS_ALS(latent_dimensions=k, max_iter=1000, random_state=0)
+        PLSALS(latent_dimensions=k, max_iter=1000, random_state=0)
         .fit(correlated_views)
         .score(correlated_views)
     )


### PR DESCRIPTION
## Summary

- Renamed every underscored algorithm-suffix class to drop the underscore, matching sklearn's own class-naming convention (`RidgeCV`, `SGDRegressor`, never `Ridge_CV`), with no exceptions: `CCA_EY`→`CCAEY`, `MCCA_EY`→`MCCAEY`, `PLS_EY`→`PLSEY`, `DCCA_EY`→`DCCAEY`, `PLS_ALS`→`PLSALS`, `SCCA_PMD`→`SCCAPMD`, `SCCA_ADMM`→`SCCAADMM`, `SCCA_IPLS`→`SCCAIPLS`, `SCCA_Span`→`SCCASpan`, `DCCA_NOI`→`DCCANOI`, `DCCA_SDL`→`DCCASDL`. Old names still work but emit a `FutureWarning` (via `sklearn.utils.deprecated`) and are excluded from `__all__`/docs.
- Renamed `GPCCA`→`GaussianProcessCCA`, matching sklearn's own `GaussianProcessRegressor`/`GaussianProcessClassifier` rather than abbreviating to `GP` — unlike `DCCA`/`KCCA`/`TCCA`/`GCCA`, `GPCCA` isn't an abbreviation inherited from an external paper, so there's no established literature form to preserve. `GAMCCA` and `TreeCCA` keep their current names (`GAM` is a self-sufficient term of art like `MLP`/`PLS`/`ARD`; `TreeCCA` already matches its own source paper's given name).
- The architecture-prefix slot (`K`/`G`/`T`/`D`/`M`/`Tree` + `CCA`) is untouched throughout, since those already match each method's own external literature abbreviation rather than being a naming-convention artifact.

## Test plan

- [x] Full test suite passes (614 passed, excluding the `probabilistic` module which requires optional `numpyro`/`jax`)
- [x] `ruff check` clean (only two pre-existing, unrelated findings remain)
- [x] `mypy` clean (no new errors introduced)
- [x] Verified old underscored names (`CCA_EY`, `SCCA_PMD`, `GPCCA`, etc.) still import and emit `FutureWarning` on instantiation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016R9fpYdbMw5yprFCtyNTfX

---
_Generated by [Claude Code](https://claude.ai/code/session_016R9fpYdbMw5yprFCtyNTfX)_