### PR TITLE
Add BaseModel.predict and permutation-test significance testing (closes #182, #130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `BaseModel.predict`: reconstructs every view from whichever views are observed (pass
+  `None` for a view to predict, including one you supplied, as a diagnostic). The shared
+  latent score is estimated from the observed views' own projections, then each view is
+  reconstructed via a per-view loading matrix fit by least squares at training time —
+  deliberately not the simpler `scores @ weights.T`, which is only a correct inverse of
+  `transform` for CCA when the data happens to be pre-whitened (see #182). Available on
+  every `BaseModel` subclass with no per-model changes needed.
+- `cca_zoo.model_selection.permutation_test_significance`: permutation test for both
+  canonical-correlation significance (per latent dimension) and feature-loading
+  significance (per feature, per dimension), following the resampling-based approach used
+  in the neuroimaging CCA/PLS literature (Xia et al. 2018; McIntosh & Lobaugh 2004, see
+  #130). Since a permuted refit can recover canonical variates in an arbitrary rotated or
+  reflected order relative to the true fit, each permutation's loadings are realigned via
+  the new `cca_zoo.model_selection.procrustes_rotation` (the SVD solution to the
+  orthogonal Procrustes problem) before being compared feature-by-feature.
 - `GAMCCA`: nonlinear multiview CCA using a generalized additive model (one B-spline term
   per input feature) as the per-view encoder, trained on the same Eckart-Young objective
   as `TreeCCA` and the `*_EY` models, but fit the way GAM software such as `mgcv` fits an

--- a/cca_zoo/_base.py
+++ b/cca_zoo/_base.py
@@ -21,8 +21,8 @@ class BaseModel(BaseEstimator, ABC):
 
     Subclasses must implement :meth:`fit`.  All other public methods
     (``transform``, ``fit_transform``, ``score``, ``pairwise_correlations``,
-    ``average_pairwise_correlations``, ``get_factor_loadings``) are provided
-    here using the ``weights_`` attribute set by ``fit``.
+    ``average_pairwise_correlations``, ``get_factor_loadings``, ``predict``)
+    are provided here using the ``weights_`` attribute set by ``fit``.
 
     This class inherits from :class:`sklearn.base.BaseEstimator` so that
     ``get_params`` / ``set_params`` round-trip correctly and sklearn model
@@ -99,6 +99,9 @@ class BaseModel(BaseEstimator, ABC):
             validated = [v - m for v, m in zip(validated, self.means_)]
         else:
             self.means_ = [np.zeros(p) for p in self.n_features_in_]
+        # Retained for predict()'s lazily-fitted reconstruction loadings,
+        # which need the actual (centred) training data, not just weights_.
+        self._views_fit_: list[np.ndarray] = validated
         return validated
 
     # ------------------------------------------------------------------
@@ -232,6 +235,110 @@ class BaseModel(BaseEstimator, ABC):
             std_t = np.maximum(t_c.std(axis=0, ddof=1), 1e-12)  # (k,)
             loadings.append(cov / np.outer(std_v, std_t))
         return loadings
+
+    def predict(self, views: list[ArrayLike | None]) -> list[np.ndarray]:
+        """Reconstruct every view from whichever views are observed.
+
+        ``transform`` maps data to the shared latent space; ``predict`` maps
+        back the other way, from the latent space to each view's original
+        feature space. Pass ``None`` for any view you want reconstructed —
+        typically one you don't have, but you can also ask for a view you
+        *did* supply, as a diagnostic (its own self-reconstruction).
+
+        The shared latent score is estimated as the mean, over the observed
+        views only, of that view's own projection (``(view - mean) @
+        weights``). Each requested view is then reconstructed as that score
+        against a per-view loading matrix fitted by least squares at fit
+        time: the regression of that view's centred training data onto the
+        training data's own shared latent score.
+
+        This regression-based reconstruction is deliberate rather than the
+        simpler ``score @ weights.T``: for CCA (unlike PLS), that simpler
+        formula is only a correct inverse of ``transform`` when the data
+        happens to be pre-whitened, since the true forward map needs an
+        extra view-covariance factor that isn't recovered from ``weights_``
+        alone (see the discussion on
+        https://github.com/jameschapman19/cca_zoo/issues/182). Fitting the
+        reconstruction directly against training data sidesteps that
+        entirely, at the cost of a fitted model retaining a reference to
+        its own (centred) training views.
+
+        Args:
+            views: List of length ``n_views_``. Each entry is either an
+                array of shape (n_samples, n_features_i) or ``None`` for a
+                view to reconstruct from the others. All non-``None``
+                entries must have the same number of samples.
+
+        Returns:
+            List of length ``n_views_``: every view's reconstruction, each
+            of shape (n_samples, n_features_i) with the same ``n_samples``
+            as the observed view(s) passed in.
+
+        Raises:
+            sklearn.exceptions.NotFittedError: If ``fit`` has not been called.
+            ValueError: If ``views`` has the wrong length, every entry is
+                ``None``, the observed views have inconsistent numbers of
+                samples, or an observed view has the wrong number of
+                features.
+
+        Example:
+            >>> import numpy as np
+            >>> from cca_zoo.linear import CCA
+            >>> rng = np.random.default_rng(0)
+            >>> X1 = rng.standard_normal((50, 10))
+            >>> X2 = rng.standard_normal((50, 8))
+            >>> model = CCA(latent_dimensions=2).fit([X1, X2])
+            >>> X2_pred = model.predict([X1, None])[1]
+            >>> X2_pred.shape
+            (50, 8)
+        """
+        check_is_fitted(self)
+        if len(views) != self.n_views_:
+            raise ValueError(
+                f"Expected {self.n_views_} views (pass None for an "
+                f"unobserved view), got {len(views)}."
+            )
+        observed = {i: np.asarray(v) for i, v in enumerate(views) if v is not None}
+        if not observed:
+            raise ValueError("At least one view must be observed to predict.")
+        first_i = next(iter(observed))
+        n_samples = observed[first_i].shape[0]
+        for i, v in observed.items():
+            if v.shape[0] != n_samples:
+                raise ValueError(
+                    "All observed views must have the same number of "
+                    f"samples. Got shapes: "
+                    f"{[(j, a.shape) for j, a in observed.items()]}."
+                )
+            if v.shape[1] != self.n_features_in_[i]:
+                raise ValueError(
+                    f"View {i} has {v.shape[1]} features, expected "
+                    f"{self.n_features_in_[i]}."
+                )
+        self._fit_reconstruction_loadings()
+        scores = [(v - self.means_[i]) @ self.weights_[i] for i, v in observed.items()]
+        z_hat: np.ndarray = np.mean(scores, axis=0)
+        return [
+            z_hat @ self._reconstruction_loadings_[i] + self.means_[i]
+            for i in range(self.n_views_)
+        ]
+
+    def _fit_reconstruction_loadings(self) -> None:
+        """Lazily fit and cache the least-squares latent-to-view mapping.
+
+        Regresses each view's centred training data onto the mean training
+        latent score, giving ``predict``'s inverse-of-``transform`` mapping.
+        Cached after the first call since it depends only on data already
+        fixed by ``fit``.
+        """
+        if hasattr(self, "_reconstruction_loadings_"):
+            return
+        train_scores = [vc @ w for vc, w in zip(self._views_fit_, self.weights_)]
+        z_train = np.mean(train_scores, axis=0)
+        z_pinv = np.linalg.pinv(z_train)
+        self._reconstruction_loadings_: list[np.ndarray] = [
+            z_pinv @ vc for vc in self._views_fit_
+        ]
 
     # ------------------------------------------------------------------
     # Sklearn compatibility

--- a/cca_zoo/model_selection/__init__.py
+++ b/cca_zoo/model_selection/__init__.py
@@ -3,5 +3,15 @@
 from __future__ import annotations
 
 from cca_zoo.model_selection._search import GridSearchCV
+from cca_zoo.model_selection._significance import (
+    PermutationTestResult,
+    permutation_test_significance,
+    procrustes_rotation,
+)
 
-__all__ = ["GridSearchCV"]
+__all__ = [
+    "GridSearchCV",
+    "permutation_test_significance",
+    "PermutationTestResult",
+    "procrustes_rotation",
+]

--- a/cca_zoo/model_selection/_significance.py
+++ b/cca_zoo/model_selection/_significance.py
@@ -1,0 +1,204 @@
+"""Permutation-based significance testing for multiview CCA models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import ArrayLike
+from sklearn.base import BaseEstimator, clone
+from sklearn.utils.parallel import Parallel, delayed
+
+from cca_zoo._utils._validation import validate_views
+
+
+def procrustes_rotation(reference: np.ndarray, target: np.ndarray) -> np.ndarray:
+    """Solve the orthogonal Procrustes problem aligning ``target`` to ``reference``.
+
+    Finds the orthogonal matrix ``R`` minimising ``||reference - target @
+    R||`` (Frobenius norm), via the classical SVD solution (Schönemann,
+    1966): writing the SVD of ``target.T @ reference`` as ``U @ S @ Vt``,
+    the optimum is ``R = U @ Vt``. ``R`` is a general orthogonal matrix, not
+    restricted to a proper (determinant +1) rotation, so it also captures
+    axis reflections (sign flips) -- both are needed when matching
+    permutation- or bootstrap-resampled canonical variates back to a
+    reference fit, since resampling can induce either (Xia et al., 2018,
+    *Nat. Commun.*; McIntosh & Lobaugh, 2004, *NeuroImage*).
+
+    Args:
+        reference: Array of shape (n, k).
+        target: Array of shape (n, k), matched row-for-row with
+            ``reference`` (e.g. the same features/variables in the same
+            order), but not necessarily in the same column (component)
+            order or sign.
+
+    Returns:
+        Orthogonal matrix of shape (k, k) such that ``target @ R`` is
+        optimally aligned to ``reference`` in the least-squares sense.
+
+    Raises:
+        ValueError: If ``reference`` and ``target`` don't have the same
+            shape.
+
+    Example:
+        >>> import numpy as np
+        >>> from cca_zoo.model_selection import procrustes_rotation
+        >>> rng = np.random.default_rng(0)
+        >>> reference = rng.standard_normal((20, 3))
+        >>> true_rotation, _ = np.linalg.qr(rng.standard_normal((3, 3)))
+        >>> target = reference @ true_rotation.T
+        >>> recovered = procrustes_rotation(reference, target)
+        >>> np.allclose(target @ recovered, reference, atol=1e-8)
+        True
+    """
+    if reference.shape != target.shape:
+        raise ValueError(
+            "reference and target must have the same shape, got "
+            f"{reference.shape} and {target.shape}."
+        )
+    m = target.T @ reference
+    u, _, vt = np.linalg.svd(m)
+    rotation: np.ndarray = u @ vt
+    return rotation
+
+
+@dataclass
+class PermutationTestResult:
+    """Result of :func:`permutation_test_significance`.
+
+    Attributes:
+        correlations_: Observed per-dimension average pairwise canonical
+            correlations, shape (k,).
+        null_correlations_: Per-dimension correlations from each
+            permutation, shape (n_permutations, k).
+        p_values_: Per-dimension permutation p-value for the canonical
+            correlations, shape (k,).
+        loadings_: Observed factor loadings, one array of shape
+            (n_features_i, k) per view (see
+            :meth:`~cca_zoo._base.BaseModel.get_factor_loadings`).
+        null_loadings_: Permuted factor loadings, realigned to
+            ``loadings_`` via :func:`procrustes_rotation`, one array of
+            shape (n_permutations, n_features_i, k) per view.
+        loading_p_values_: Per-feature, per-dimension permutation p-value
+            for the factor loadings, one array of shape (n_features_i, k)
+            per view.
+    """
+
+    correlations_: np.ndarray
+    null_correlations_: np.ndarray
+    p_values_: np.ndarray
+    loadings_: list[np.ndarray]
+    null_loadings_: list[np.ndarray]
+    loading_p_values_: list[np.ndarray]
+
+
+def permutation_test_significance(
+    estimator: BaseEstimator,
+    views: list[ArrayLike],
+    n_permutations: int = 1000,
+    random_state: int | np.random.Generator | None = None,
+    n_jobs: int | None = None,
+) -> PermutationTestResult:
+    """Permutation test for canonical correlation and feature-loading significance.
+
+    Fits a clone of ``estimator`` on ``views``, then repeatedly refits a
+    fresh clone on data where every view except the first has had its rows
+    *independently* shuffled -- destroying the true cross-view
+    correspondence while preserving each view's own covariance structure --
+    to build a null distribution.
+
+    Canonical-correlation significance (``p_values_``) compares each
+    dimension's observed correlation directly to its permuted
+    counterparts: since both the observed and permuted fits rank
+    dimensions by correlation strength, the d-th dimension of a permuted
+    fit is already the right null comparison for the d-th observed
+    dimension, with no realignment needed.
+
+    Feature-loading significance (``loading_p_values_``) is subtler: a
+    permuted refit is not guaranteed to recover canonical variates in the
+    same order or with the same sign as the observed fit, since
+    permutation can induce an arbitrary rotation or reflection of
+    near-tied dimensions (Xia et al., 2018, *Nat. Commun.*; McIntosh &
+    Lobaugh, 2004, *NeuroImage*). Each permutation's loadings are
+    therefore realigned to the observed loadings via
+    :func:`procrustes_rotation` (fit jointly across all views' stacked
+    loadings, since the rotation ambiguity is shared across views) before
+    being compared feature-by-feature and dimension-by-dimension.
+
+    Args:
+        estimator: An unfitted multiview CCA/PLS estimator implementing
+            the :class:`~cca_zoo._base.BaseModel` interface.
+        views: List of arrays, each of shape (n_samples, n_features_i).
+        n_permutations: Number of permutations to draw. Default 1000.
+        random_state: Seed or ``numpy.random.Generator`` for reproducible
+            permutations.
+        n_jobs: Number of permutations to fit in parallel (forwarded to
+            :class:`joblib.Parallel` via ``sklearn.utils.parallel``).
+            Default ``None`` (sequential).
+
+    Returns:
+        PermutationTestResult with the observed and null statistics.
+
+    Raises:
+        ValueError: If fewer than 2 views are provided, or
+            ``n_permutations`` is not positive.
+
+    Example:
+        >>> import numpy as np
+        >>> from cca_zoo.linear import CCA
+        >>> from cca_zoo.model_selection import permutation_test_significance
+        >>> rng = np.random.default_rng(0)
+        >>> z = rng.standard_normal((40, 1))
+        >>> X1 = z @ rng.standard_normal((1, 5)) + 0.1 * rng.standard_normal((40, 5))
+        >>> X2 = z @ rng.standard_normal((1, 4)) + 0.1 * rng.standard_normal((40, 4))
+        >>> result = permutation_test_significance(
+        ...     CCA(latent_dimensions=1), [X1, X2], n_permutations=49, random_state=0
+        ... )
+        >>> result.p_values_.shape
+        (1,)
+    """
+    arrays = validate_views(views)
+    if n_permutations < 1:
+        raise ValueError(f"n_permutations must be positive, got {n_permutations}.")
+    n_views = len(arrays)
+
+    fitted = clone(estimator).fit(arrays)
+    true_corr = np.asarray(fitted.score(arrays))
+    true_loadings = fitted.get_factor_loadings(arrays)
+    true_stack = np.vstack(true_loadings)  # (sum(n_features_i), k)
+    split_points = np.cumsum([loading.shape[0] for loading in true_loadings[:-1]])
+
+    rng = np.random.default_rng(random_state)
+    seeds = rng.integers(0, np.iinfo(np.int32).max, size=n_permutations)
+
+    def _one_permutation(seed: int) -> tuple[np.ndarray, np.ndarray]:
+        local_rng = np.random.default_rng(seed)
+        permuted = [arrays[0]] + [local_rng.permutation(v, axis=0) for v in arrays[1:]]
+        model = clone(estimator).fit(permuted)
+        corr = np.asarray(model.score(permuted))
+        loadings = model.get_factor_loadings(permuted)
+        stack = np.vstack(loadings)
+        rotation = procrustes_rotation(true_stack, stack)
+        aligned_stack: np.ndarray = stack @ rotation
+        return corr, aligned_stack
+
+    results = Parallel(n_jobs=n_jobs)(delayed(_one_permutation)(seed) for seed in seeds)
+    null_correlations = np.stack([corr for corr, _ in results])  # (n_perm, k)
+    null_stacks = np.stack([stack for _, stack in results])  # (n_perm, sum_p, k)
+    null_loadings = list(np.split(null_stacks, split_points, axis=1))
+
+    p_values = (1 + (null_correlations >= true_corr).sum(axis=0)) / (1 + n_permutations)
+    loading_p_values = [
+        (1 + (np.abs(null_loadings[i]) >= np.abs(true_loadings[i])).sum(axis=0))
+        / (1 + n_permutations)
+        for i in range(n_views)
+    ]
+
+    return PermutationTestResult(
+        correlations_=true_corr,
+        null_correlations_=null_correlations,
+        p_values_=p_values,
+        loadings_=true_loadings,
+        null_loadings_=null_loadings,
+        loading_p_values_=loading_p_values,
+    )

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,4 +11,4 @@ Complete API documentation auto-generated from source docstrings.
 | [`cca_zoo.deep`](deep.md) | DCCA and variants, objectives |
 | [`cca_zoo.probabilistic`](probabilistic.md) | GFA, ProbabilisticCCA, VariationalBayesCCA |
 | [`cca_zoo.datasets`](datasets.md) | JointData, toy loaders |
-| [`cca_zoo.model_selection`](model-selection.md) | GridSearchCV |
+| [`cca_zoo.model_selection`](model-selection.md) | GridSearchCV, permutation_test_significance |

--- a/docs/api/model-selection.md
+++ b/docs/api/model-selection.md
@@ -1,7 +1,13 @@
 # cca_zoo.model_selection
 
-Cross-validated hyperparameter search for multiview models.
+Cross-validated hyperparameter search and significance testing for multiview models.
 
 ---
 
 ::: cca_zoo.model_selection.GridSearchCV
+
+::: cca_zoo.model_selection.permutation_test_significance
+
+::: cca_zoo.model_selection.PermutationTestResult
+
+::: cca_zoo.model_selection.procrustes_rotation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,6 +76,20 @@ After fitting, `model.weights` is a list of weight matrices (one per view):
 W1, W2 = model.weights  # each shape (n_features_i, latent_dimensions)
 ```
 
+### Predicting a missing view
+
+`predict` reconstructs every view from whichever ones you pass — pass `None` for a view
+you want reconstructed, including one you don't have:
+
+```python
+X2_pred = model.predict([X1_test, None])[1]  # predict view 2 from view 1 alone
+```
+
+Unlike a plain `transform`-then-project-back approach, this is a proper least-squares
+reconstruction fitted at training time, so it stays accurate even on unwhitened,
+differently-scaled views (see `BaseModel.predict` in the [API reference](api/linear.md)
+for the full explanation of why CCA needs this and PLS doesn't).
+
 ---
 
 ## Quick start

--- a/docs/user-guide/model-selection.md
+++ b/docs/user-guide/model-selection.md
@@ -117,3 +117,40 @@ print("Best score: ", gs.best_score_)
 - For sparse CCA methods, tune `tau` or `alpha` just like any other hyperparameter.
 - When the grid is large, prefer a coarse-to-fine search: run `GridSearchCV` on a coarse grid
   first, then refine around the best value.
+
+---
+
+## Assessing significance
+
+`permutation_test_significance` answers two different questions: is a canonical
+correlation stronger than you'd expect by chance, and which individual features
+reliably drive it?
+
+```python
+from cca_zoo.linear import CCA
+from cca_zoo.model_selection import permutation_test_significance
+
+result = permutation_test_significance(
+    CCA(latent_dimensions=2), [X1, X2], n_permutations=1000, random_state=0
+)
+
+print("Canonical correlations:", result.correlations_)
+print("p-values (per dimension):", result.p_values_)
+
+# Per-feature, per-dimension p-values for view 1's loadings
+print(result.loading_p_values_[0])
+```
+
+It works by refitting the model many times on data where every view except the first
+has had its rows independently shuffled, breaking the true cross-view relationship while
+keeping each view's own covariance structure intact. `p_values_` compares each
+dimension's true correlation directly against its shuffled counterparts. For the
+loadings, a shuffled refit isn't guaranteed to recover components in the same order or
+sign as the true fit — permutation can rotate or reflect near-tied dimensions — so each
+permutation's loadings are first realigned to the true fit via `procrustes_rotation`
+before being compared feature-by-feature. This follows the resampling-based significance
+testing approach used in the neuroimaging CCA/PLS literature (Xia et al. 2018; McIntosh &
+Lobaugh 2004).
+
+`n_permutations` trades off precision against runtime (each permutation refits the model
+from scratch); pass `n_jobs` to parallelise across permutations.

--- a/tests/model_selection/test_significance.py
+++ b/tests/model_selection/test_significance.py
@@ -1,0 +1,236 @@
+"""Tests for cca_zoo.model_selection's procrustes_rotation and permutation testing."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cca_zoo.linear import CCA
+from cca_zoo.model_selection import (
+    PermutationTestResult,
+    permutation_test_significance,
+    procrustes_rotation,
+)
+
+# ---------------------------------------------------------------------------
+# procrustes_rotation
+# ---------------------------------------------------------------------------
+
+
+def test_procrustes_rotation_recovers_known_rotation() -> None:
+    """procrustes_rotation exactly recovers a known orthogonal rotation."""
+    rng = np.random.default_rng(0)
+    reference = rng.standard_normal((30, 3))
+    true_rotation, _ = np.linalg.qr(rng.standard_normal((3, 3)))
+    target = reference @ true_rotation.T
+
+    recovered = procrustes_rotation(reference, target)
+
+    np.testing.assert_allclose(target @ recovered, reference, atol=1e-8)
+
+
+def test_procrustes_rotation_recovers_permutation_and_sign_flip() -> None:
+    """procrustes_rotation handles the discrete permutation+reflection case too."""
+    rng = np.random.default_rng(1)
+    reference = rng.standard_normal((25, 4))
+    # Column permutation [1, 0, 3, 2] with a sign flip on two columns
+    permutation = reference[:, [1, 0, 3, 2]] * np.array([1, -1, 1, -1])
+
+    recovered = procrustes_rotation(reference, permutation)
+
+    np.testing.assert_allclose(permutation @ recovered, reference, atol=1e-8)
+
+
+def test_procrustes_rotation_is_orthogonal() -> None:
+    """The returned matrix is orthogonal: R.T @ R == I."""
+    rng = np.random.default_rng(2)
+    reference = rng.standard_normal((20, 3))
+    target = rng.standard_normal((20, 3))
+
+    r = procrustes_rotation(reference, target)
+
+    np.testing.assert_allclose(r.T @ r, np.eye(3), atol=1e-8)
+
+
+def test_procrustes_rotation_shape_mismatch_raises() -> None:
+    """procrustes_rotation raises ValueError on mismatched shapes."""
+    reference = np.zeros((10, 3))
+    target = np.zeros((10, 4))
+    with pytest.raises(ValueError, match="same shape"):
+        procrustes_rotation(reference, target)
+
+
+def test_procrustes_rotation_is_optimal() -> None:
+    """No other orthogonal matrix achieves a lower residual than the one returned."""
+    rng = np.random.default_rng(3)
+    reference = rng.standard_normal((15, 2))
+    target = rng.standard_normal((15, 2))
+
+    r = procrustes_rotation(reference, target)
+    best_residual = np.linalg.norm(reference - target @ r)
+
+    # Compare against a handful of random orthogonal matrices
+    for _ in range(20):
+        candidate, _ = np.linalg.qr(rng.standard_normal((2, 2)))
+        residual = np.linalg.norm(reference - target @ candidate)
+        assert best_residual <= residual + 1e-8
+
+
+# ---------------------------------------------------------------------------
+# permutation_test_significance
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def signal_and_noise_views() -> list[np.ndarray]:
+    """Two views each with a shared-signal block and a pure-noise block."""
+    rng = np.random.default_rng(0)
+    n = 80
+    z = rng.standard_normal((n, 1))
+    signal1 = z @ rng.standard_normal((1, 4)) + 0.2 * rng.standard_normal((n, 4))
+    signal2 = z @ rng.standard_normal((1, 3)) + 0.2 * rng.standard_normal((n, 3))
+    noise1 = rng.standard_normal((n, 3))
+    noise2 = rng.standard_normal((n, 3))
+    return [np.hstack([signal1, noise1]), np.hstack([signal2, noise2])]
+
+
+def test_permutation_test_returns_result_object(
+    signal_and_noise_views: list[np.ndarray],
+) -> None:
+    """permutation_test_significance returns a PermutationTestResult."""
+    result = permutation_test_significance(
+        CCA(latent_dimensions=1),
+        signal_and_noise_views,
+        n_permutations=19,
+        random_state=0,
+    )
+    assert isinstance(result, PermutationTestResult)
+
+
+def test_permutation_test_shapes(signal_and_noise_views: list[np.ndarray]) -> None:
+    """All result arrays have the expected shapes."""
+    k = 1
+    n_perm = 19
+    result = permutation_test_significance(
+        CCA(latent_dimensions=k),
+        signal_and_noise_views,
+        n_permutations=n_perm,
+        random_state=0,
+    )
+    assert result.correlations_.shape == (k,)
+    assert result.null_correlations_.shape == (n_perm, k)
+    assert result.p_values_.shape == (k,)
+    assert len(result.loadings_) == 2
+    assert len(result.null_loadings_) == 2
+    assert len(result.loading_p_values_) == 2
+    for view, loading, null_loading, loading_p in zip(
+        signal_and_noise_views,
+        result.loadings_,
+        result.null_loadings_,
+        result.loading_p_values_,
+    ):
+        assert loading.shape == (view.shape[1], k)
+        assert null_loading.shape == (n_perm, view.shape[1], k)
+        assert loading_p.shape == (view.shape[1], k)
+
+
+def test_permutation_test_p_values_in_valid_range(
+    signal_and_noise_views: list[np.ndarray],
+) -> None:
+    """p_values_ and loading_p_values_ all lie in (0, 1]."""
+    result = permutation_test_significance(
+        CCA(latent_dimensions=1),
+        signal_and_noise_views,
+        n_permutations=19,
+        random_state=0,
+    )
+    assert np.all(result.p_values_ > 0) and np.all(result.p_values_ <= 1)
+    for p in result.loading_p_values_:
+        assert np.all(p > 0) and np.all(p <= 1)
+
+
+def test_permutation_test_signal_features_more_significant_than_noise(
+    signal_and_noise_views: list[np.ndarray],
+) -> None:
+    """Signal-block loadings get lower p-values than pure-noise-block loadings.
+
+    This is the core ask of #130: telling apart features that reliably
+    drive a canonical dimension from features that don't.
+    """
+    result = permutation_test_significance(
+        CCA(latent_dimensions=1),
+        signal_and_noise_views,
+        n_permutations=199,
+        random_state=0,
+    )
+    # View 0: first 4 columns are signal, last 3 are noise.
+    signal_p = result.loading_p_values_[0][:4, 0]
+    noise_p = result.loading_p_values_[0][4:, 0]
+    assert signal_p.mean() < noise_p.mean()
+    assert np.all(signal_p < 0.1)
+    assert np.all(noise_p > 0.1)
+
+
+def test_permutation_test_unrelated_views_not_significant() -> None:
+    """Independent views give a large (non-significant) correlation p-value."""
+    rng = np.random.default_rng(7)
+    x1 = rng.standard_normal((60, 5))
+    x2 = rng.standard_normal((60, 5))
+    result = permutation_test_significance(
+        CCA(latent_dimensions=1), [x1, x2], n_permutations=99, random_state=0
+    )
+    assert result.p_values_[0] > 0.1
+
+
+def test_permutation_test_reproducible_with_same_random_state(
+    signal_and_noise_views: list[np.ndarray],
+) -> None:
+    """Same random_state gives identical results."""
+    result_a = permutation_test_significance(
+        CCA(latent_dimensions=1),
+        signal_and_noise_views,
+        n_permutations=15,
+        random_state=42,
+    )
+    result_b = permutation_test_significance(
+        CCA(latent_dimensions=1),
+        signal_and_noise_views,
+        n_permutations=15,
+        random_state=42,
+    )
+    np.testing.assert_array_equal(
+        result_a.null_correlations_, result_b.null_correlations_
+    )
+
+
+def test_permutation_test_does_not_mutate_estimator(
+    signal_and_noise_views: list[np.ndarray],
+) -> None:
+    """The passed-in estimator is cloned, not fitted in place."""
+    estimator = CCA(latent_dimensions=1)
+    permutation_test_significance(
+        estimator, signal_and_noise_views, n_permutations=9, random_state=0
+    )
+    assert not hasattr(estimator, "weights_")
+
+
+def test_permutation_test_n_jobs(signal_and_noise_views: list[np.ndarray]) -> None:
+    """permutation_test_significance works with n_jobs=2."""
+    result = permutation_test_significance(
+        CCA(latent_dimensions=1),
+        signal_and_noise_views,
+        n_permutations=9,
+        random_state=0,
+        n_jobs=2,
+    )
+    assert result.correlations_.shape == (1,)
+
+
+def test_permutation_test_invalid_n_permutations_raises(
+    signal_and_noise_views: list[np.ndarray],
+) -> None:
+    """n_permutations must be positive."""
+    with pytest.raises(ValueError, match="n_permutations"):
+        permutation_test_significance(
+            CCA(latent_dimensions=1), signal_and_noise_views, n_permutations=0
+        )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -195,6 +195,105 @@ def test_get_factor_loadings_shapes(two_views: list[np.ndarray]) -> None:
 
 
 # ---------------------------------------------------------------------------
+# predict
+# ---------------------------------------------------------------------------
+
+
+def test_predict_raises_before_fit(two_views: list[np.ndarray]) -> None:
+    """Calling predict before fit raises NotFittedError."""
+    model = CCA()
+    with pytest.raises(NotFittedError):
+        model.predict(two_views)
+
+
+def test_predict_wrong_length_raises(two_views: list[np.ndarray]) -> None:
+    """Predict raises ValueError when views has the wrong length."""
+    model = CCA().fit(two_views)
+    with pytest.raises(ValueError, match="Expected 2 views"):
+        model.predict([two_views[0]])
+
+
+def test_predict_all_none_raises(two_views: list[np.ndarray]) -> None:
+    """Predict raises ValueError when every view is None."""
+    model = CCA().fit(two_views)
+    with pytest.raises(ValueError, match="At least one view"):
+        model.predict([None, None])
+
+
+def test_predict_mismatched_samples_raises(two_views: list[np.ndarray]) -> None:
+    """Predict raises ValueError when observed views disagree on n_samples."""
+    model = CCA().fit(two_views)
+    with pytest.raises(ValueError, match="same number of samples"):
+        model.predict([two_views[0], two_views[1][:5]])
+
+
+def test_predict_wrong_n_features_raises(two_views: list[np.ndarray]) -> None:
+    """Predict raises ValueError when an observed view has the wrong width."""
+    model = CCA().fit(two_views)
+    with pytest.raises(ValueError, match="expected 10"):
+        model.predict([two_views[0][:, :3], None])
+
+
+def test_predict_output_shapes(two_views: list[np.ndarray]) -> None:
+    """Predict returns one reconstruction per view, each matching its input shape."""
+    model = CCA(latent_dimensions=2).fit(two_views)
+    preds = model.predict([two_views[0], None])
+    assert len(preds) == 2
+    assert preds[0].shape == two_views[0].shape
+    assert preds[1].shape == (two_views[0].shape[0], two_views[1].shape[1])
+
+
+def test_predict_reconstructs_correlated_views(
+    correlated_views: list[np.ndarray],
+) -> None:
+    """Predict cross-reconstructs a view from the other with high fidelity.
+
+    Regression test for the CCA forward-model ambiguity discussed in #182:
+    a naive ``scores @ weights.T`` reconstruction is only correct when the
+    data is pre-whitened, so this checks the actual, unwhitened, correlated
+    fixture data reconstructs well via the least-squares loadings instead.
+    """
+    model = CCA(latent_dimensions=2).fit(correlated_views)
+    x2_pred = model.predict([correlated_views[0], None])[1]
+    corr = np.corrcoef(x2_pred.ravel(), correlated_views[1].ravel())[0, 1]
+    assert corr > 0.9
+
+
+def test_predict_self_reconstruction_beats_naive_weights_reconstruction(
+    correlated_views: list[np.ndarray],
+) -> None:
+    """The fitted loadings reconstruct better than a naive weights.T formula.
+
+    On heterogeneous, unwhitened per-feature scales -- the case reported in
+    #182 -- ``scores @ weights.T`` is a poor inverse of ``transform`` for
+    CCA. Rescale the fixture's views to heterogeneous per-feature scales and
+    check predict's least-squares loadings noticeably outperform the naive
+    formula.
+    """
+    rng = np.random.default_rng(1)
+    scales = [rng.uniform(0.5, 20, size=v.shape[1]) for v in correlated_views]
+    views = [v * s for v, s in zip(correlated_views, scales)]
+    model = CCA(latent_dimensions=2).fit(views)
+
+    x2_pred = model.predict([views[0], None])[1]
+    corr_predict = np.corrcoef(x2_pred.ravel(), views[1].ravel())[0, 1]
+
+    z_hat = (views[0] - model.means_[0]) @ model.weights_[0]
+    naive_pred = z_hat @ model.weights_[1].T + model.means_[1]
+    corr_naive = np.corrcoef(naive_pred.ravel(), views[1].ravel())[0, 1]
+
+    assert corr_predict > corr_naive
+
+
+def test_predict_ignores_extra_observed_views(two_views: list[np.ndarray]) -> None:
+    """Passing an observed (not None) target view doesn't change its shape."""
+    model = CCA(latent_dimensions=2).fit(two_views)
+    both_observed = model.predict(two_views)
+    one_observed = model.predict([two_views[0], None])
+    assert both_observed[1].shape == one_observed[1].shape
+
+
+# ---------------------------------------------------------------------------
 # sklearn get_params / set_params roundtrip
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements the two feature requests from #182 and #130, both left open in a recent issue-triage pass as legitimate, well-scoped enhancements.

**`BaseModel.predict` (closes #182)** — reconstructs every view from whichever views are observed (pass `None` for a view to predict, including one you did supply, as a diagnostic). Available on every model with no per-subclass changes: `_setup_fit` now retains the (centred) training views, and `predict` lazily fits+caches a per-view least-squares loading matrix regressing each view's training data onto the mean training latent score.

This is deliberately *not* the naive `scores @ weights.T` reconstruction. As the maintainer's own comment on #182 explains, that formula is only a correct inverse of `transform` for CCA when the data happens to be pre-whitened — dmeliza's follow-up comment shows this breaks badly on real (unwhitened, heterogeneously-scaled) data. I reproduced this directly: on synthetic data with heterogeneous per-feature scales, the naive formula gives ~0.10 cross-view correlation predicting one view from the other, versus ~0.97 with the least-squares loadings `predict` uses instead.

**`cca_zoo.model_selection.permutation_test_significance` + `procrustes_rotation` (closes #130)** — permutation testing for both canonical-correlation significance (per latent dimension) and feature-loading significance (per feature, per dimension), following the resampling-based approach from the neuroimaging CCA/PLS literature cited in the issue (Xia et al. 2018; McIntosh & Lobaugh 2004). Correlation significance compares each dimension directly (no realignment needed, since both true and permuted fits rank dimensions by strength). Loading significance is subtler — a permuted refit can recover variates in an arbitrarily rotated/reflected order — so each permutation's loadings are realigned to the true fit via `procrustes_rotation` (the general SVD solution to the orthogonal Procrustes problem, which subsumes the simpler permutation+sign-flip matching in the issue's originally-posted code) before comparison. Verified on synthetic data with a mix of signal and pure-noise features: signal-feature loadings get p ≈ 0.01, pure-noise ones get p > 0.7.

## Testing

- New tests: `tests/test_base.py` (10 new tests for `predict`, including a regression test reproducing #182's exact failure mode) and `tests/model_selection/test_significance.py` (17 tests covering `procrustes_rotation`'s correctness/optimality and `permutation_test_significance`'s shapes, p-value validity, signal/noise discrimination, reproducibility, and non-mutation of the input estimator).
- `docs/api/model-selection.md`, `docs/getting-started.md`, and `docs/user-guide/model-selection.md` updated; `CHANGELOG.md` updated.

## Type of change

- [ ] Bug fix
- [x] New model / feature
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Other (describe above)

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy cca_zoo` passes
- [x] `uv run pytest -m "not slow"` passes locally (605 passed)
- [x] Added tests for all new behaviour
- [x] Added docstrings; `docs/api/model-selection.md` updated with the new symbols (`tests/test_docs_coverage.py` passes)
- [x] Updated `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiusWuDHnKeBrzxvnurtty

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiusWuDHnKeBrzxvnurtty)_