### PR TITLE
Add BaseModel.inverse_transform (closes #195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `BaseModel.inverse_transform`: reconstructs each view from *that same view's own*
+  latent score (typically `transform`'s output), via a per-view loading matrix fit by
+  least squares at training time -- an approximate round trip with `transform`, mirroring
+  `sklearn.decomposition.PCA.inverse_transform` (see #195). Distinct from `predict`, which
+  combines the *observed* views into one shared consensus score to reconstruct views you
+  don't have; `inverse_transform` never mixes information across views. Available on
+  every `BaseModel` subclass with no per-model changes needed.
 - `BaseModel.predict`: reconstructs every view from whichever views are observed (pass
   `None` for a view to predict, including one you supplied, as a diagnostic). The shared
   latent score is estimated from the observed views' own projections, then each view is

--- a/cca_zoo/_base.py
+++ b/cca_zoo/_base.py
@@ -20,9 +20,10 @@ class BaseModel(BaseEstimator, ABC):
     """Abstract base class for all multiview CCA models.
 
     Subclasses must implement :meth:`fit`.  All other public methods
-    (``transform``, ``fit_transform``, ``score``, ``pairwise_correlations``,
-    ``average_pairwise_correlations``, ``get_factor_loadings``, ``predict``)
-    are provided here using the ``weights_`` attribute set by ``fit``.
+    (``transform``, ``inverse_transform``, ``fit_transform``, ``score``,
+    ``pairwise_correlations``, ``average_pairwise_correlations``,
+    ``get_factor_loadings``, ``predict``) are provided here using the
+    ``weights_`` attribute set by ``fit``.
 
     This class inherits from :class:`sklearn.base.BaseEstimator` so that
     ``get_params`` / ``set_params`` round-trip correctly and sklearn model
@@ -99,8 +100,9 @@ class BaseModel(BaseEstimator, ABC):
             validated = [v - m for v, m in zip(validated, self.means_)]
         else:
             self.means_ = [np.zeros(p) for p in self.n_features_in_]
-        # Retained for predict()'s lazily-fitted reconstruction loadings,
-        # which need the actual (centred) training data, not just weights_.
+        # Retained for predict()'s and inverse_transform()'s lazily-fitted
+        # reconstruction loadings, which need the actual (centred) training
+        # data, not just weights_.
         self._views_fit_: list[np.ndarray] = validated
         return validated
 
@@ -124,6 +126,70 @@ class BaseModel(BaseEstimator, ABC):
         validated = validate_views(views)
         centred = [v - m for v, m in zip(validated, self.means_)]
         return [v @ w for v, w in zip(centred, self.weights_)]
+
+    def inverse_transform(self, scores: list[ArrayLike]) -> list[np.ndarray]:
+        """Approximately invert ``transform``, mapping latent scores back to each view.
+
+        Each view is reconstructed from *that same view's own* latent
+        score only, via a per-view loading matrix fit by least squares at
+        fit time: the regression of that view's centred training data onto
+        that view's own training latent score. This makes
+        ``inverse_transform(transform(views))`` an approximate round trip
+        of ``views`` (exact wherever ``latent_dimensions`` and each view's
+        own weights span it exactly), mirroring
+        :meth:`sklearn.decomposition.PCA.inverse_transform`.
+
+        This is a different operation from :meth:`predict`: ``predict``
+        combines the *observed* views' scores into one shared consensus
+        estimate to reconstruct views you don't have, which is only
+        possible once at least one other view actually is observed.
+        ``inverse_transform`` never mixes information across views — it
+        needs a view's own score to reconstruct that same view, so it
+        cannot be used to impute a view you never transformed in the first
+        place; use :meth:`predict` for that.
+
+        Args:
+            scores: List of length ``n_views_``, each an array of shape
+                (n_samples, latent_dimensions) — typically the output of
+                :meth:`transform`.
+
+        Returns:
+            List of length ``n_views_``, each an array of shape
+            (n_samples, n_features_i): the reconstructed view.
+
+        Raises:
+            sklearn.exceptions.NotFittedError: If ``fit`` has not been called.
+            ValueError: If ``scores`` has the wrong length, or an entry has
+                the wrong number of latent dimensions.
+
+        Example:
+            >>> import numpy as np
+            >>> from cca_zoo.linear import CCA
+            >>> rng = np.random.default_rng(0)
+            >>> X1 = rng.standard_normal((50, 10))
+            >>> X2 = rng.standard_normal((50, 8))
+            >>> model = CCA(latent_dimensions=2).fit([X1, X2])
+            >>> scores = model.transform([X1, X2])
+            >>> X1_approx, X2_approx = model.inverse_transform(scores)
+            >>> X1_approx.shape
+            (50, 10)
+        """
+        check_is_fitted(self)
+        if len(scores) != self.n_views_:
+            raise ValueError(
+                f"Expected {self.n_views_} score arrays, got {len(scores)}."
+            )
+        arrays = [np.asarray(s) for s in scores]
+        for i, s in enumerate(arrays):
+            if s.shape[1] != self.latent_dimensions:
+                raise ValueError(
+                    f"scores[{i}] has {s.shape[1]} columns, expected "
+                    f"latent_dimensions={self.latent_dimensions}."
+                )
+        self._fit_view_loadings()
+        return [
+            s @ self._view_loadings_[i] + self.means_[i] for i, s in enumerate(arrays)
+        ]
 
     def fit_transform(self, views: list[ArrayLike], y: None = None) -> list[np.ndarray]:
         """Fit and then transform the training data.
@@ -263,6 +329,11 @@ class BaseModel(BaseEstimator, ABC):
         entirely, at the cost of a fitted model retaining a reference to
         its own (centred) training views.
 
+        See also :meth:`inverse_transform`, which reconstructs a view from
+        that same view's own score (no cross-view imputation) — the
+        appropriate choice when you already have every view's scores and
+        just want to invert ``transform``.
+
         Args:
             views: List of length ``n_views_``. Each entry is either an
                 array of shape (n_samples, n_features_i) or ``None`` for a
@@ -338,6 +409,22 @@ class BaseModel(BaseEstimator, ABC):
         z_pinv = np.linalg.pinv(z_train)
         self._reconstruction_loadings_: list[np.ndarray] = [
             z_pinv @ vc for vc in self._views_fit_
+        ]
+
+    def _fit_view_loadings(self) -> None:
+        """Lazily fit and cache each view's own inverse-of-``transform`` mapping.
+
+        Regresses each view's centred training data onto *that same
+        view's own* training latent score (unlike
+        :meth:`_fit_reconstruction_loadings`, which regresses onto the
+        mean score across all views). Cached after the first call since
+        it depends only on data already fixed by ``fit``.
+        """
+        if hasattr(self, "_view_loadings_"):
+            return
+        self._view_loadings_: list[np.ndarray] = [
+            np.linalg.pinv(vc @ w) @ vc
+            for vc, w in zip(self._views_fit_, self.weights_)
         ]
 
     # ------------------------------------------------------------------

--- a/docs/api/linear.md
+++ b/docs/api/linear.md
@@ -12,6 +12,8 @@ Linear CCA methods. All classes are `sklearn.base.BaseEstimator` subclasses.
       members:
         - fit
         - transform
+        - inverse_transform
+        - predict
         - fit_transform
         - score
         - pairwise_correlations

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,6 +90,20 @@ reconstruction fitted at training time, so it stays accurate even on unwhitened,
 differently-scaled views (see `BaseModel.predict` in the [API reference](api/linear.md)
 for the full explanation of why CCA needs this and PLS doesn't).
 
+### Reconstructing a view from its own score
+
+`inverse_transform` is `predict`'s narrower sibling: it undoes `transform` for a view
+using *that view's own* score only, with no cross-view imputation —
+
+```python
+z1, z2 = model.transform([X1_test, X2_test])
+X1_approx, X2_approx = model.inverse_transform([z1, z2])
+```
+
+Use `inverse_transform` when you already have every view's scores (e.g. after denoising
+or perturbing them) and just want to map back to feature space; use `predict` when you
+have some views but not others.
+
 ---
 
 ## Quick start

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -294,6 +294,97 @@ def test_predict_ignores_extra_observed_views(two_views: list[np.ndarray]) -> No
 
 
 # ---------------------------------------------------------------------------
+# inverse_transform
+# ---------------------------------------------------------------------------
+
+
+def test_inverse_transform_raises_before_fit(two_views: list[np.ndarray]) -> None:
+    """Calling inverse_transform before fit raises NotFittedError."""
+    model = CCA()
+    with pytest.raises(NotFittedError):
+        model.inverse_transform(two_views)
+
+
+def test_inverse_transform_wrong_length_raises(two_views: list[np.ndarray]) -> None:
+    """inverse_transform raises ValueError when scores has the wrong length."""
+    model = CCA(latent_dimensions=2).fit(two_views)
+    scores = model.transform(two_views)
+    with pytest.raises(ValueError, match="Expected 2 score arrays"):
+        model.inverse_transform([scores[0]])
+
+
+def test_inverse_transform_wrong_n_latent_dims_raises(
+    two_views: list[np.ndarray],
+) -> None:
+    """inverse_transform raises ValueError when a score array has the wrong width."""
+    model = CCA(latent_dimensions=2).fit(two_views)
+    scores = model.transform(two_views)
+    with pytest.raises(ValueError, match="expected latent_dimensions=2"):
+        model.inverse_transform([scores[0][:, :1], scores[1]])
+
+
+def test_inverse_transform_output_shapes(two_views: list[np.ndarray]) -> None:
+    """inverse_transform returns one reconstruction per view, matching its width."""
+    model = CCA(latent_dimensions=2).fit(two_views)
+    scores = model.transform(two_views)
+    approx = model.inverse_transform(scores)
+    assert len(approx) == 2
+    for a, view in zip(approx, two_views):
+        assert a.shape == view.shape
+
+
+def test_inverse_transform_round_trips_correlated_views(
+    correlated_views: list[np.ndarray],
+) -> None:
+    """inverse_transform(transform(views)) approximately recovers views."""
+    model = CCA(latent_dimensions=2).fit(correlated_views)
+    scores = model.transform(correlated_views)
+    approx = model.inverse_transform(scores)
+    for a, view in zip(approx, correlated_views):
+        corr = np.corrcoef(a.ravel(), view.ravel())[0, 1]
+        assert corr > 0.9
+
+
+def test_inverse_transform_round_trips_on_heterogeneous_scales(
+    correlated_views: list[np.ndarray],
+) -> None:
+    """The round trip holds even on unwhitened, heterogeneously-scaled views.
+
+    Unlike predict's cross-view reconstruction, inverse_transform never
+    needs to correct for the CCA forward-model whitening subtlety from
+    #182/#195, since it regresses each view onto its own score rather than
+    a consensus score borrowed from another view -- this checks that
+    holds even when features are rescaled to very different magnitudes.
+    """
+    rng = np.random.default_rng(2)
+    scales = [rng.uniform(0.5, 20, size=v.shape[1]) for v in correlated_views]
+    views = [v * s for v, s in zip(correlated_views, scales)]
+    model = CCA(latent_dimensions=2).fit(views)
+    scores = model.transform(views)
+    approx = model.inverse_transform(scores)
+    for a, view in zip(approx, views):
+        corr = np.corrcoef(a.ravel(), view.ravel())[0, 1]
+        assert corr > 0.9
+
+
+def test_inverse_transform_differs_from_predict(
+    correlated_views: list[np.ndarray],
+) -> None:
+    """inverse_transform and predict answer different questions.
+
+    inverse_transform reconstructs a view from its own score;
+    predict reconstructs it from other views' scores. On two correlated
+    but distinct views, they should not give numerically identical
+    reconstructions of view 2.
+    """
+    model = CCA(latent_dimensions=2).fit(correlated_views)
+    scores = model.transform(correlated_views)
+    via_inverse_transform = model.inverse_transform(scores)[1]
+    via_predict = model.predict([correlated_views[0], None])[1]
+    assert not np.allclose(via_inverse_transform, via_predict)
+
+
+# ---------------------------------------------------------------------------
 # sklearn get_params / set_params roundtrip
 # ---------------------------------------------------------------------------
 

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -7,6 +7,18 @@ matching mkdocstrings ``::: `` line to the corresponding API reference
 page. docs/api/*.md isn't auto-generated from ``__all__`` (it's hand
 -curated into meaningful categories with headers), so this test is the
 mechanical backstop that catches the gap instead.
+
+It also guards a narrower version of the same failure mode one level
+down: mkdocstrings shows every public member of a documented class by
+default, but ``docs/api/linear.md`` overrides that for ``BaseModel`` with
+an explicit ``members:`` allowlist (to control display order). That
+allowlist is hand-maintained, so ``BaseModel.predict`` shipped in #240
+without being added to it and silently rendered nothing in the API
+reference until #242 noticed. ``BaseDeep``/``JointData``/``objectives``
+have similar ``members:`` overrides but are deliberately curated
+subsets of their class's full public surface, not "all of it", so
+they're not covered here -- only ``BaseModel``, where the allowlist is
+meant to be exhaustive.
 """
 
 from __future__ import annotations
@@ -16,6 +28,8 @@ import re
 from pathlib import Path
 
 import pytest
+
+from cca_zoo._base import BaseModel
 
 DOCS_API_DIR = Path(__file__).parent.parent / "docs" / "api"
 
@@ -57,4 +71,64 @@ def test_all_public_symbols_are_documented(module_name: str) -> None:
         f"{module_name}.__all__ contains names with no docs/api/"
         f"{MODULE_DOC_PAGES[module_name]} entry: {missing}. "
         "Add a `::: ...` line for each, grouped under the relevant heading."
+    )
+
+
+def _members_list_for(doc_path: Path, dotted_path: str) -> list[str]:
+    """Extract the mkdocstrings ``members:`` list following a ``::: <path>`` line."""
+    lines = doc_path.read_text().splitlines()
+    for i, line in enumerate(lines):
+        if line.strip() == f"::: {dotted_path}":
+            break
+    else:
+        raise AssertionError(f"No '::: {dotted_path}' directive found in {doc_path}")
+
+    members = []
+    in_members = False
+    for line in lines[i + 1 :]:
+        stripped = line.strip()
+        if stripped == "members:":
+            in_members = True
+            continue
+        if in_members:
+            if stripped.startswith("- "):
+                members.append(stripped[2:].strip())
+                continue
+            break
+        if stripped.startswith("::: ") or stripped == "---":
+            break
+    return members
+
+
+def test_basemodel_members_list_matches_public_api() -> None:
+    """docs/api/linear.md's BaseModel `members:` allowlist tracks its public API.
+
+    BaseModel documents its methods via an explicit `members:` list rather
+    than mkdocstrings' default "show every public member" behaviour, so a
+    newly added public method silently renders nothing in the API
+    reference until someone remembers to add it here by hand -- exactly
+    what happened to `predict` in #240. This is the mechanical backstop
+    for that specific failure mode.
+    """
+    doc_path = DOCS_API_DIR / MODULE_DOC_PAGES["cca_zoo.linear"]
+    documented = set(_members_list_for(doc_path, "cca_zoo._base.BaseModel"))
+    # sklearn's BaseEstimator.__init_subclass__ auto-injects a
+    # set_<method>_request(...) metadata-routing setter onto every
+    # subclass for each method that can take routed metadata -- framework
+    # noise, not part of cca_zoo's own curated public API.
+    actual = {
+        name
+        for name in vars(BaseModel)
+        if not name.startswith("_") and not re.fullmatch(r"set_\w+_request", name)
+    }
+
+    missing = actual - documented
+    assert not missing, (
+        f"BaseModel has public member(s) {missing} not listed in "
+        f"{doc_path}'s `members:` block. Add them there."
+    )
+    extra = documented - actual
+    assert not extra, (
+        f"{doc_path}'s `members:` block lists {extra}, which are no "
+        "longer public members defined directly on BaseModel. Remove them."
     )


### PR DESCRIPTION
## Summary

Implements #195, the last of the three remaining issue-triage feature requests I flagged as well-scoped (following #182/`predict` and #130/`permutation_test_significance`, both merged in #240).

**`BaseModel.inverse_transform(scores)`** reconstructs each view from *that same view's own* latent score (typically `transform`'s output), via a per-view loading matrix fit by least squares at training time — an approximate round trip with `transform`, mirroring `sklearn.decomposition.PCA.inverse_transform`. Available on every model with no per-subclass changes, reusing the `_views_fit_` training-data reference `predict` (#240) already introduced.

This is a genuinely different operation from `predict`, not a duplicate:
- `predict` combines the *observed* views into one shared consensus score to reconstruct views you don't have (cross-view imputation).
- `inverse_transform` never mixes information across views — it needs a view's own score to reconstruct that same view (the direct undo of `transform`).

I verified both give numerically different reconstructions of the same view on correlated test data, and that `inverse_transform`'s round trip holds even on unwhitened, heterogeneously-scaled views — it never needs `predict`'s whitening correction (#182), since it never regresses one view's data against another view's score.

**Also fixed:** `docs/api/linear.md`'s `BaseModel` `members:` allowlist never had `predict` added when #240 merged, so it wasn't rendering in the API reference at all despite being implemented and tested. Added both `predict` and `inverse_transform` to that list and confirmed via a local `mkdocs build --strict` that both now render.

## Testing

- 8 new tests in `tests/test_base.py`: error paths, output shapes, round-trip correlation on correlated views, round-trip correlation under heterogeneous scaling, and a test confirming `inverse_transform` and `predict` give different results (proving they're not accidentally the same operation).
- `docs/getting-started.md` and `CHANGELOG.md` updated.

## Type of change

- [ ] Bug fix
- [x] New model / feature
- [ ] Documentation
- [ ] Refactor / internal change
- [ ] Other (describe above)

## Checklist

- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy cca_zoo` passes
- [x] `uv run pytest -m "not slow"` passes locally (612 passed)
- [x] Added tests for all new/changed behaviour
- [x] Added docstrings; `docs/api/linear.md` updated (`mkdocs build --strict` confirms rendering)
- [x] Updated `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiusWuDHnKeBrzxvnurtty

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiusWuDHnKeBrzxvnurtty)_